### PR TITLE
chore: modernize build — Java 21, explicit JUnit engine, Spotless + enforcer

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,6 @@
+# Bulk formatting / whitespace-only revisions to skip in `git blame`.
+# Enable locally with:
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# style: apply Palantir Java format across the codebase
+763d7ffac88fab99bdaf6e3a53fbe6a304ca9fc9

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,8 +20,8 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v7
 
-      # JDK 21 (LTS): the pom targets --release 12, which needs a JDK >= 12,
-      # so the repo's older JDK 11 CI configs cannot build this project.
+      # JDK 21 (LTS): the pom targets --release 21, matching the JavaFX 21
+      # runtime, so the build requires a JDK >= 21.
       - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,31 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.6.1</version>
+        <executions>
+          <execution>
+            <id>enforce-build-environment</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireJavaVersion>
+                  <version>[21,)</version>
+                </requireJavaVersion>
+                <requireMavenVersion>
+                  <version>[3.9,)</version>
+                </requireMavenVersion>
+                <dependencyConvergence/>
+                <banDuplicatePomDependencyVersions/>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.5.4</version>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,30 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>2.44.5</version>
+        <configuration>
+          <java>
+            <palantirJavaFormat/>
+            <removeUnusedImports/>
+            <importOrder/>
+            <trimTrailingWhitespace/>
+            <endWithNewline/>
+          </java>
+        </configuration>
+        <executions>
+          <execution>
+            <id>spotless-check</id>
+            <!-- Runs during `mvn test`, which is what CI invokes -->
+            <phase>process-sources</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.5.4</version>

--- a/pom.xml
+++ b/pom.xml
@@ -13,9 +13,22 @@
     <encoding>UTF-8</encoding>
     <java.version>21</java.version>
     <javafx.version>21.0.12</javafx.version>
+    <junit.version>6.1.2</junit.version>
     <mainClassName>ca.ciccc.silverBullet.SilverBulletApp</mainClassName>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <!-- Aligns every JUnit artifact (api, engine, launcher) to one version -->
+      <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>${junit.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <!-- https://mvnrepository.com/artifact/org.openjfx/javafx-controls -->
@@ -48,15 +61,21 @@
       <artifactId>javafx-media</artifactId>
       <version>${javafx.version}</version>
     </dependency>
+    <!-- Aggregator brings the Jupiter API + engine so Surefire no longer has
+         to auto-provision the engine implicitly; version comes from junit-bom -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <version>6.1.2</version>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.4</version>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <properties>
     <encoding>UTF-8</encoding>
-    <java.version>12</java.version>
+    <java.version>21</java.version>
     <javafx.version>21.0.12</javafx.version>
     <mainClassName>ca.ciccc.silverBullet.SilverBulletApp</mainClassName>
   </properties>
@@ -42,18 +42,6 @@
       <artifactId>javafx-base</artifactId>
       <version>${javafx.version}</version>
     </dependency>
-    <!-- https://mvnrepository.com/artifact/org.openjfx/javafx-web -->
-    <dependency>
-      <groupId>org.openjfx</groupId>
-      <artifactId>javafx-web</artifactId>
-      <version>${javafx.version}</version>
-    </dependency>
-    <!-- https://mvnrepository.com/artifact/org.openjfx/javafx-swing -->
-    <dependency>
-      <groupId>org.openjfx</groupId>
-      <artifactId>javafx-swing</artifactId>
-      <version>${javafx.version}</version>
-    </dependency>
     <!-- https://mvnrepository.com/artifact/org.openjfx/javafx-media -->
     <dependency>
       <groupId>org.openjfx</groupId>
@@ -74,7 +62,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.15.0</version>
         <configuration>
-          <release>12</release>
+          <release>21</release>
         </configuration>
       </plugin>
       <plugin>
@@ -82,7 +70,7 @@
         <artifactId>javafx-maven-plugin</artifactId>
         <version>0.0.8</version>
         <configuration>
-          <release>12</release>
+          <release>21</release>
           <jlinkImageName>jlinkImage</jlinkImageName>
           <launcher>silverBullet</launcher>
           <mainClass>${mainClassName}</mainClass>

--- a/src/main/java/ca/ciccc/silverBullet/SilverBulletApp.java
+++ b/src/main/java/ca/ciccc/silverBullet/SilverBulletApp.java
@@ -2,35 +2,31 @@ package ca.ciccc.silverBullet;
 
 import ca.ciccc.silverBullet.controller.MenuController;
 import ca.ciccc.silverBullet.utils.ConstUtil;
-import java.io.File;
-import java.nio.file.Paths;
 import java.util.ResourceBundle;
 import javafx.application.Application;
 import javafx.stage.Stage;
-
 
 /**
  * SilverBulletApp
  */
 public class SilverBulletApp extends Application {
 
-  public static Stage primaryStage;
+    public static Stage primaryStage;
 
-  public static void main(String[] args) {
-    ConstUtil.setResourceBundle(ResourceBundle.getBundle("ca/ciccc/silverBullet/application"));
+    public static void main(String[] args) {
+        ConstUtil.setResourceBundle(ResourceBundle.getBundle("ca/ciccc/silverBullet/application"));
 
-    Application.launch();
-  }
+        Application.launch();
+    }
 
-  @Override
-  public void start(Stage primaryStage) {
-    SilverBulletApp.primaryStage = primaryStage;
-    primaryStage.setTitle(ConstUtil.APP_NAME);
+    @Override
+    public void start(Stage primaryStage) {
+        SilverBulletApp.primaryStage = primaryStage;
+        primaryStage.setTitle(ConstUtil.APP_NAME);
 
-    // Start Menu
-    MenuController.getInstance().show();
+        // Start Menu
+        MenuController.getInstance().show();
 
-    primaryStage.show();
-
-  }
+        primaryStage.show();
+    }
 }

--- a/src/main/java/ca/ciccc/silverBullet/controller/AbstractController.java
+++ b/src/main/java/ca/ciccc/silverBullet/controller/AbstractController.java
@@ -3,6 +3,4 @@ package ca.ciccc.silverBullet.controller;
 /**
  * AbstractController
  */
-public abstract class AbstractController {
-
-}
+public abstract class AbstractController {}

--- a/src/main/java/ca/ciccc/silverBullet/controller/AbstractMenuController.java
+++ b/src/main/java/ca/ciccc/silverBullet/controller/AbstractMenuController.java
@@ -1,22 +1,19 @@
 package ca.ciccc.silverBullet.controller;
 
-
 import ca.ciccc.silverBullet.utils.MediaUtil;
 import javafx.scene.media.AudioClip;
 
 public abstract class AbstractMenuController extends AbstractController {
 
-  protected static final AudioClip MENU_CLIP =
-      MediaUtil.createClip("/audios/BitShift.wav");
+    protected static final AudioClip MENU_CLIP = MediaUtil.createClip("/audios/BitShift.wav");
 
-  public static AudioClip getMenuClip() {
-    return MENU_CLIP;
-  }
+    public static AudioClip getMenuClip() {
+        return MENU_CLIP;
+    }
 
-  public static AudioClip getBattleClip() {
-    return BATTLE_CLIP;
-  }
+    public static AudioClip getBattleClip() {
+        return BATTLE_CLIP;
+    }
 
-  protected static final AudioClip BATTLE_CLIP =
-      MediaUtil.createClip("/audios/Overworld.wav");
+    protected static final AudioClip BATTLE_CLIP = MediaUtil.createClip("/audios/Overworld.wav");
 }

--- a/src/main/java/ca/ciccc/silverBullet/controller/GameController.java
+++ b/src/main/java/ca/ciccc/silverBullet/controller/GameController.java
@@ -11,48 +11,48 @@ import javafx.scene.paint.Color;
  * @author Masa
  */
 public class GameController extends AbstractController {
-  private static GameController instance;
-  private static GameScene game;
-  public AnimationTimer timer;
+    private static GameController instance;
+    private static GameScene game;
+    public AnimationTimer timer;
 
-  static {
-    instance = new GameController();
-  }
-
-  /**
-   * Return singleton instance
-   * @return instance
-   */
-  public static GameController getInstance() {
-    synchronized (GameController.class) {
-      if (instance == null) {
+    static {
         instance = new GameController();
-      }
-      return instance;
     }
-  }
 
-  void show(int players, int level, int turnSeconds) {
-    game = new GameScene.Builder()
-        .player(players)
-        .level(level)
-        .turnSeconds(turnSeconds).build();
-    game.setStyle("-fx-background-color: #000000;");
-    game.setPrefSize(900, 700);
-    Scene scene = new Scene(game);
-    scene.setOnKeyPressed(e -> game.onKeyPressed(e.getCode()));
-    scene.setFill(Color.TRANSPARENT);
+    /**
+     * Return singleton instance
+     * @return instance
+     */
+    public static GameController getInstance() {
+        synchronized (GameController.class) {
+            if (instance == null) {
+                instance = new GameController();
+            }
+            return instance;
+        }
+    }
 
-    timer = new AnimationTimer() {
-      @Override
-      public void handle(long l) {
-        game.boardUpdate();
-      }
-    };
-    game.setOnStop(timer::stop);
-    timer.start();
+    void show(int players, int level, int turnSeconds) {
+        game = new GameScene.Builder()
+                .player(players)
+                .level(level)
+                .turnSeconds(turnSeconds)
+                .build();
+        game.setStyle("-fx-background-color: #000000;");
+        game.setPrefSize(900, 700);
+        Scene scene = new Scene(game);
+        scene.setOnKeyPressed(e -> game.onKeyPressed(e.getCode()));
+        scene.setFill(Color.TRANSPARENT);
 
-    SilverBulletApp.primaryStage.setScene(scene);
-  }
+        timer = new AnimationTimer() {
+            @Override
+            public void handle(long l) {
+                game.boardUpdate();
+            }
+        };
+        game.setOnStop(timer::stop);
+        timer.start();
 
+        SilverBulletApp.primaryStage.setScene(scene);
+    }
 }

--- a/src/main/java/ca/ciccc/silverBullet/controller/HowToPlayController.java
+++ b/src/main/java/ca/ciccc/silverBullet/controller/HowToPlayController.java
@@ -28,142 +28,133 @@ import javafx.scene.text.Text;
  */
 public class HowToPlayController extends AbstractMenuController {
 
-  private static HowToPlayController instance;
-  private static Scene SCENE;
-  private static final String[] TITLE_ARY = {
-      "1. COMMAND PHASE",
-      "2. EXECUTION PHASE"
-  };
-  private static final String[] IMAGE_PATH_ARY = {
-      "/images/Menu/HowToPlay_command.png",
-      "/images/Menu/HowToPlay_execution.png"
-  };
+    private static HowToPlayController instance;
+    private static Scene SCENE;
+    private static final String[] TITLE_ARY = {"1. COMMAND PHASE", "2. EXECUTION PHASE"};
+    private static final String[] IMAGE_PATH_ARY = {
+        "/images/Menu/HowToPlay_command.png", "/images/Menu/HowToPlay_execution.png"
+    };
 
-  private static final Color SLIDER_NOT_SELECTED_COLOR =
-      Color.rgb(76, 248, 87, 0.4);
-  private static final Color SLIDER_SELECTED_COLOR =
-      Color.rgb(76, 248, 87, 1);
+    private static final Color SLIDER_NOT_SELECTED_COLOR = Color.rgb(76, 248, 87, 0.4);
+    private static final Color SLIDER_SELECTED_COLOR = Color.rgb(76, 248, 87, 1);
 
-  private List<Image> imageList = new ArrayList<>();
-  private List<Circle> imageSliderList = new ArrayList<>();
+    private List<Image> imageList = new ArrayList<>();
+    private List<Circle> imageSliderList = new ArrayList<>();
 
-  @FXML
-  private Text titleText;
-  @FXML
-  private ImageView imageView;
-  @FXML
-  private HBox imageSlider;
+    @FXML
+    private Text titleText;
 
-  static {
-    FXMLLoader fxmlLoader = new FXMLLoader();
-    try {
-      fxmlLoader.load(
-          HowToPlayController.class.getModule().getResourceAsStream(
-              "ca/ciccc/silverBullet/fxml/howToPlay.fxml"
-          ));
-    } catch (IOException e) {
-      e.printStackTrace();
-    }
-    Parent parent = fxmlLoader.getRoot();
-    Scene scene = new Scene(parent);
-    scene.setFill(Color.TRANSPARENT);
-    SCENE = scene;
-    instance = fxmlLoader.getController();
+    @FXML
+    private ImageView imageView;
 
-    // Set images and texts
-    instance.imageList.addAll(Arrays.stream(IMAGE_PATH_ARY)
-        .map(MediaUtil::createImage)
-        .collect(Collectors.toList()));
-    instance.imageView.setImage(instance.imageList.get(0));
-    instance.titleText.setText(TITLE_ARY[0]);
+    @FXML
+    private HBox imageSlider;
 
-    // Add image slider
-    IntStream.range(0, IMAGE_PATH_ARY.length).forEach(i -> {
-      Circle imageSlider = instance.createImageSlider();
-      instance.imageSliderList.add(imageSlider);
-      instance.imageSlider.getChildren().add(
-          instance.imageSlider.getChildren().size() - 1,
-          imageSlider
-      );
-      if (i != IMAGE_PATH_ARY.length - 1) {
-        HBox.setMargin(imageSlider, new Insets(0, 10, 0, 0));
-      }
-    });
+    static {
+        FXMLLoader fxmlLoader = new FXMLLoader();
+        try {
+            fxmlLoader.load(HowToPlayController.class
+                    .getModule()
+                    .getResourceAsStream("ca/ciccc/silverBullet/fxml/howToPlay.fxml"));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        Parent parent = fxmlLoader.getRoot();
+        Scene scene = new Scene(parent);
+        scene.setFill(Color.TRANSPARENT);
+        SCENE = scene;
+        instance = fxmlLoader.getController();
 
-    // Add onKeyEvent
-    SCENE.setOnKeyPressed(e -> {
-      switch (e.getCode()) {
-        case LEFT:
-          instance.onLeftSignClicked(null);
-          break;
-        case RIGHT:
-          instance.onRightSignClicked(null);
-          break;
-        default:
-          break;
-      }
-    });
+        // Set images and texts
+        instance.imageList.addAll(
+                Arrays.stream(IMAGE_PATH_ARY).map(MediaUtil::createImage).collect(Collectors.toList()));
+        instance.imageView.setImage(instance.imageList.get(0));
+        instance.titleText.setText(TITLE_ARY[0]);
 
-    instance.imageSliderList.get(0).setFill(SLIDER_SELECTED_COLOR);
+        // Add image slider
+        IntStream.range(0, IMAGE_PATH_ARY.length).forEach(i -> {
+            Circle imageSlider = instance.createImageSlider();
+            instance.imageSliderList.add(imageSlider);
+            instance.imageSlider
+                    .getChildren()
+                    .add(instance.imageSlider.getChildren().size() - 1, imageSlider);
+            if (i != IMAGE_PATH_ARY.length - 1) {
+                HBox.setMargin(imageSlider, new Insets(0, 10, 0, 0));
+            }
+        });
 
-  }
+        // Add onKeyEvent
+        SCENE.setOnKeyPressed(e -> {
+            switch (e.getCode()) {
+                case LEFT:
+                    instance.onLeftSignClicked(null);
+                    break;
+                case RIGHT:
+                    instance.onRightSignClicked(null);
+                    break;
+                default:
+                    break;
+            }
+        });
 
-  /**
-   * Return singleton instance
-   *
-   * @return instance
-   */
-  public static HowToPlayController getInstance() {
-    synchronized (HowToPlayController.class) {
-      if (instance == null) {
-        instance = new HowToPlayController();
-      }
-      return instance;
-    }
-  }
-
-  public void show() {
-    SilverBulletApp.primaryStage.setScene(SCENE);
-  }
-
-  @FXML
-  void onLeftSignClicked(MouseEvent event) {
-    int index = this.imageList.indexOf(this.imageView.getImage());
-    this.imageSliderList.get(index).setFill(SLIDER_NOT_SELECTED_COLOR);
-    if (index == 0) {
-      index = this.imageList.size();
+        instance.imageSliderList.get(0).setFill(SLIDER_SELECTED_COLOR);
     }
 
-    this.slide(--index);
-  }
-
-  @FXML
-  void onRightSignClicked(MouseEvent event) {
-    int index = this.imageList.indexOf(this.imageView.getImage());
-    this.imageSliderList.get(index).setFill(SLIDER_NOT_SELECTED_COLOR);
-    if (index == this.imageList.size() - 1) {
-      index = -1;
+    /**
+     * Return singleton instance
+     *
+     * @return instance
+     */
+    public static HowToPlayController getInstance() {
+        synchronized (HowToPlayController.class) {
+            if (instance == null) {
+                instance = new HowToPlayController();
+            }
+            return instance;
+        }
     }
 
-    this.slide(++index);
-  }
+    public void show() {
+        SilverBulletApp.primaryStage.setScene(SCENE);
+    }
 
-  private void slide(int newIndex) {
-    this.titleText.setText(TITLE_ARY[newIndex]);
-    this.imageView.setImage(instance.imageList.get(newIndex));
-    this.imageSliderList.get(newIndex).setFill(SLIDER_SELECTED_COLOR);
-  }
+    @FXML
+    void onLeftSignClicked(MouseEvent event) {
+        int index = this.imageList.indexOf(this.imageView.getImage());
+        this.imageSliderList.get(index).setFill(SLIDER_NOT_SELECTED_COLOR);
+        if (index == 0) {
+            index = this.imageList.size();
+        }
 
-  @FXML
-  public void onBackToMenuClicked() {
-    MenuController.getInstance().show();
-  }
+        this.slide(--index);
+    }
 
-  private Circle createImageSlider() {
-    Circle result = new Circle();
-    result.setRadius(15);
-    result.setFill(SLIDER_NOT_SELECTED_COLOR);
-    return result;
-  }
+    @FXML
+    void onRightSignClicked(MouseEvent event) {
+        int index = this.imageList.indexOf(this.imageView.getImage());
+        this.imageSliderList.get(index).setFill(SLIDER_NOT_SELECTED_COLOR);
+        if (index == this.imageList.size() - 1) {
+            index = -1;
+        }
 
+        this.slide(++index);
+    }
+
+    private void slide(int newIndex) {
+        this.titleText.setText(TITLE_ARY[newIndex]);
+        this.imageView.setImage(instance.imageList.get(newIndex));
+        this.imageSliderList.get(newIndex).setFill(SLIDER_SELECTED_COLOR);
+    }
+
+    @FXML
+    public void onBackToMenuClicked() {
+        MenuController.getInstance().show();
+    }
+
+    private Circle createImageSlider() {
+        Circle result = new Circle();
+        result.setRadius(15);
+        result.setFill(SLIDER_NOT_SELECTED_COLOR);
+        return result;
+    }
 }

--- a/src/main/java/ca/ciccc/silverBullet/controller/MenuController.java
+++ b/src/main/java/ca/ciccc/silverBullet/controller/MenuController.java
@@ -18,82 +18,75 @@ import javafx.scene.text.Text;
  * @author Masa
  */
 public class MenuController extends AbstractMenuController {
-  private static MenuController instance;
-  private static Scene SCENE;
+    private static MenuController instance;
+    private static Scene SCENE;
 
-  static {
-    FXMLLoader fxmlLoader = new FXMLLoader();
-    try {
-      fxmlLoader.load(
-          MenuController.class.getModule().getResourceAsStream(
-              "ca/ciccc/silverBullet/fxml/menu.fxml")
-      );
-    } catch (IOException e) {
-      e.printStackTrace();
-    }
-    Parent parent = fxmlLoader.getRoot();
-    Scene scene = new Scene(parent);
-    scene.setFill(Color.TRANSPARENT);
-    SCENE = scene;
-    instance = fxmlLoader.getController();
-  }
-
-  /**
-   * Return singleton instance
-   *
-   * @return instance
-   */
-  public static MenuController getInstance() {
-    synchronized (MenuController.class) {
-      if (instance == null) {
-        instance = new MenuController();
-      }
-      return instance;
-    }
-  }
-
-  public void show() {
-    if (!AbstractMenuController.MENU_CLIP.isPlaying()) {
-      MENU_CLIP.setCycleCount(Integer.MAX_VALUE);
-      AbstractMenuController.MENU_CLIP.play();
+    static {
+        FXMLLoader fxmlLoader = new FXMLLoader();
+        try {
+            fxmlLoader.load(
+                    MenuController.class.getModule().getResourceAsStream("ca/ciccc/silverBullet/fxml/menu.fxml"));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        Parent parent = fxmlLoader.getRoot();
+        Scene scene = new Scene(parent);
+        scene.setFill(Color.TRANSPARENT);
+        SCENE = scene;
+        instance = fxmlLoader.getController();
     }
 
-    if (AbstractMenuController.BATTLE_CLIP.isPlaying()) {
-      BATTLE_CLIP.setCycleCount(Integer.MAX_VALUE);
-      AbstractMenuController.BATTLE_CLIP.stop();
+    /**
+     * Return singleton instance
+     *
+     * @return instance
+     */
+    public static MenuController getInstance() {
+        synchronized (MenuController.class) {
+            if (instance == null) {
+                instance = new MenuController();
+            }
+            return instance;
+        }
     }
-    SilverBulletApp.primaryStage.setScene(SCENE);
-  }
 
-  @FXML
-  public void OnStartClicked() {
-    SettingsController.getInstance().show();
-  }
+    public void show() {
+        if (!AbstractMenuController.MENU_CLIP.isPlaying()) {
+            MENU_CLIP.setCycleCount(Integer.MAX_VALUE);
+            AbstractMenuController.MENU_CLIP.play();
+        }
 
-  @FXML
-  public void OnHowToPlayClicked() {
-    HowToPlayController.getInstance().show();
-  }
+        if (AbstractMenuController.BATTLE_CLIP.isPlaying()) {
+            BATTLE_CLIP.setCycleCount(Integer.MAX_VALUE);
+            AbstractMenuController.BATTLE_CLIP.stop();
+        }
+        SilverBulletApp.primaryStage.setScene(SCENE);
+    }
 
-  @FXML
-  public void OnQuitClicked() {
-    ModalUtil.confirm(
-        "QUIT",
-        "Did you really want to quit?",
-        () -> System.exit(1)
-    );
-  }
+    @FXML
+    public void OnStartClicked() {
+        SettingsController.getInstance().show();
+    }
 
-  @FXML
-  public void OnEntered(MouseEvent event) {
-    Text text = (Text) ((StackPane)event.getSource()).getChildren().get(0);
-    text.setText("▷ " + text.getText());
-  }
+    @FXML
+    public void OnHowToPlayClicked() {
+        HowToPlayController.getInstance().show();
+    }
 
-  @FXML
-  public void OnExited(MouseEvent event) {
-    Text text = (Text) ((StackPane)event.getSource()).getChildren().get(0);
-    text.setText(text.getText().replace("▷ ", ""));
-  }
+    @FXML
+    public void OnQuitClicked() {
+        ModalUtil.confirm("QUIT", "Did you really want to quit?", () -> System.exit(1));
+    }
 
+    @FXML
+    public void OnEntered(MouseEvent event) {
+        Text text = (Text) ((StackPane) event.getSource()).getChildren().get(0);
+        text.setText("▷ " + text.getText());
+    }
+
+    @FXML
+    public void OnExited(MouseEvent event) {
+        Text text = (Text) ((StackPane) event.getSource()).getChildren().get(0);
+        text.setText(text.getText().replace("▷ ", ""));
+    }
 }

--- a/src/main/java/ca/ciccc/silverBullet/controller/SettingsController.java
+++ b/src/main/java/ca/ciccc/silverBullet/controller/SettingsController.java
@@ -21,124 +21,109 @@ import javafx.scene.paint.Color;
  */
 public class SettingsController extends AbstractMenuController {
 
-  private static SettingsController instance;
-  private static Scene SCENE;
+    private static SettingsController instance;
+    private static Scene SCENE;
 
-  @FXML
-  private ComboBox<Integer> howManyPlayersCombo;
-  @FXML
-  private ComboBox<Integer> gameLevelCombo;
-  @FXML
-  private ComboBox<WaitTime> waitTimeCombo;
+    @FXML
+    private ComboBox<Integer> howManyPlayersCombo;
 
-  static {
-    FXMLLoader fxmlLoader = new FXMLLoader();
-    try {
-      fxmlLoader.load(
-          SettingsController.class.getModule().getResourceAsStream(
-              "ca/ciccc/silverBullet/fxml/settings.fxml")
-      );
-    } catch (IOException e) {
-      e.printStackTrace();
+    @FXML
+    private ComboBox<Integer> gameLevelCombo;
+
+    @FXML
+    private ComboBox<WaitTime> waitTimeCombo;
+
+    static {
+        FXMLLoader fxmlLoader = new FXMLLoader();
+        try {
+            fxmlLoader.load(SettingsController.class
+                    .getModule()
+                    .getResourceAsStream("ca/ciccc/silverBullet/fxml/settings.fxml"));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        Parent parent = fxmlLoader.getRoot();
+        Scene scene = new Scene(parent);
+        scene.setFill(Color.TRANSPARENT);
+        SCENE = scene;
+        instance = fxmlLoader.getController();
     }
-    Parent parent = fxmlLoader.getRoot();
-    Scene scene = new Scene(parent);
-    scene.setFill(Color.TRANSPARENT);
-    SCENE = scene;
-    instance = fxmlLoader.getController();
-  }
 
-  /**
-   * Return singleton instance
-   *
-   * @return instance
-   */
-  public static SettingsController getInstance() {
-    synchronized (SettingsController.class) {
-      if (instance == null) {
-        instance = new SettingsController();
-      }
-      return instance;
-    }
-  }
-
-  public void show() {
-    if (howManyPlayersCombo.getItems().size() == 0) {
-      // Set combo values
-      this.howManyPlayersCombo.getItems()
-          .addAll(
-              Arrays.stream(ConstUtil.PLAYER_NUMBERS)
-                  .boxed()
-                  .collect(Collectors.toList())
-          );
-      this.gameLevelCombo.getItems()
-          .addAll(
-              Arrays.stream(ConstUtil.GAME_LEVEL_NUMBERS)
-                  .boxed()
-                  .collect(Collectors.toList())
-          );
-      this.waitTimeCombo.getItems().addAll(WaitTime.values());
-
-      // Set default value
-      this.howManyPlayersCombo.getSelectionModel().select(ConstUtil.DEFAULT_PLAYER_NUMBER_INDEX);
-      this.gameLevelCombo.getSelectionModel().select(ConstUtil.DEFAULT_GAME_LEVEL_INDEX);
-      this.waitTimeCombo.getSelectionModel().select(WaitTime.DEFAULT);
-
-    }
-    SilverBulletApp.primaryStage.setScene(SCENE);
-  }
-
-  private boolean validate() {
-    return !this.howManyPlayersCombo.getSelectionModel().isEmpty()
-        && !this.gameLevelCombo.getSelectionModel().isEmpty()
-        && !this.waitTimeCombo.getSelectionModel().isEmpty();
-  }
-
-  @FXML
-  public void onStartClicked() {
-
-    if (!validate()) {
-      ModalUtil.alert("INVALID SETTINGS",
-          "There is an empty option"
-      );
-    } else {
-      ModalUtil.confirm("START",
-          "Are you ready?",
-          () -> {
-            GameController.getInstance().show(
-                this.howManyPlayersCombo.getSelectionModel().getSelectedItem(),
-                this.gameLevelCombo.getSelectionModel().getSelectedItem(),
-                this.waitTimeCombo.getSelectionModel().getSelectedItem().getSeconds()
-            );
-            if (AbstractMenuController.MENU_CLIP.isPlaying()) {
-              AbstractMenuController.MENU_CLIP.stop();
-              AbstractMenuController.BATTLE_CLIP.play();
-              AbstractMenuController.BATTLE_CLIP.setCycleCount(999999);
-
+    /**
+     * Return singleton instance
+     *
+     * @return instance
+     */
+    public static SettingsController getInstance() {
+        synchronized (SettingsController.class) {
+            if (instance == null) {
+                instance = new SettingsController();
             }
-          }
-      );
+            return instance;
+        }
     }
-  }
 
-  @FXML
-  public void onBackToMenuClicked() {
-    ModalUtil.confirm("BACK TO MENU",
-        "Go back to menu?",
-        () -> MenuController.getInstance().show()
-    );
-  }
+    public void show() {
+        if (howManyPlayersCombo.getItems().size() == 0) {
+            // Set combo values
+            this.howManyPlayersCombo
+                    .getItems()
+                    .addAll(Arrays.stream(ConstUtil.PLAYER_NUMBERS).boxed().collect(Collectors.toList()));
+            this.gameLevelCombo
+                    .getItems()
+                    .addAll(Arrays.stream(ConstUtil.GAME_LEVEL_NUMBERS).boxed().collect(Collectors.toList()));
+            this.waitTimeCombo.getItems().addAll(WaitTime.values());
 
-  @FXML
-  public void OnEntered() {
-  }
+            // Set default value
+            this.howManyPlayersCombo.getSelectionModel().select(ConstUtil.DEFAULT_PLAYER_NUMBER_INDEX);
+            this.gameLevelCombo.getSelectionModel().select(ConstUtil.DEFAULT_GAME_LEVEL_INDEX);
+            this.waitTimeCombo.getSelectionModel().select(WaitTime.DEFAULT);
+        }
+        SilverBulletApp.primaryStage.setScene(SCENE);
+    }
 
-  @FXML
-  public void OnPressed() {
-  }
+    private boolean validate() {
+        return !this.howManyPlayersCombo.getSelectionModel().isEmpty()
+                && !this.gameLevelCombo.getSelectionModel().isEmpty()
+                && !this.waitTimeCombo.getSelectionModel().isEmpty();
+    }
 
-  @FXML
-  public void OnExited() {
-  }
+    @FXML
+    public void onStartClicked() {
 
+        if (!validate()) {
+            ModalUtil.alert("INVALID SETTINGS", "There is an empty option");
+        } else {
+            ModalUtil.confirm("START", "Are you ready?", () -> {
+                GameController.getInstance()
+                        .show(
+                                this.howManyPlayersCombo.getSelectionModel().getSelectedItem(),
+                                this.gameLevelCombo.getSelectionModel().getSelectedItem(),
+                                this.waitTimeCombo
+                                        .getSelectionModel()
+                                        .getSelectedItem()
+                                        .getSeconds());
+                if (AbstractMenuController.MENU_CLIP.isPlaying()) {
+                    AbstractMenuController.MENU_CLIP.stop();
+                    AbstractMenuController.BATTLE_CLIP.play();
+                    AbstractMenuController.BATTLE_CLIP.setCycleCount(999999);
+                }
+            });
+        }
+    }
+
+    @FXML
+    public void onBackToMenuClicked() {
+        ModalUtil.confirm("BACK TO MENU", "Go back to menu?", () -> MenuController.getInstance()
+                .show());
+    }
+
+    @FXML
+    public void OnEntered() {}
+
+    @FXML
+    public void OnPressed() {}
+
+    @FXML
+    public void OnExited() {}
 }

--- a/src/main/java/ca/ciccc/silverBullet/enums/gameplay/Directions.java
+++ b/src/main/java/ca/ciccc/silverBullet/enums/gameplay/Directions.java
@@ -9,7 +9,10 @@ package ca.ciccc.silverBullet.enums.gameplay;
  * movement/turning rules testable in isolation.
  */
 public enum Directions {
-    NORTH, SOUTH, EAST, WEST;
+    NORTH,
+    SOUTH,
+    EAST,
+    WEST;
 
     /**
      * Horizontal step for one tile of movement in this direction.

--- a/src/main/java/ca/ciccc/silverBullet/enums/gameplay/GridElement.java
+++ b/src/main/java/ca/ciccc/silverBullet/enums/gameplay/GridElement.java
@@ -5,49 +5,47 @@ import ca.ciccc.silverBullet.gridNodes.GridNode;
 import ca.ciccc.silverBullet.gridNodes.Hole;
 import ca.ciccc.silverBullet.gridNodes.Space;
 import ca.ciccc.silverBullet.gridNodes.Wall;
-import ca.ciccc.silverBullet.gridNodes.Water;
 import java.util.Arrays;
 import java.util.Optional;
 
 public enum GridElement {
-  HOLE('H'),
-  WALL('W'),
-  SPACE('S'),
-  EDGE('E'),
-  PICKUP('P'),
-  ONE('1'),
-  TWO('2'),
-  THREE('3'),
-  FOUR('4');
+    HOLE('H'),
+    WALL('W'),
+    SPACE('S'),
+    EDGE('E'),
+    PICKUP('P'),
+    ONE('1'),
+    TWO('2'),
+    THREE('3'),
+    FOUR('4');
 
-  private char letter;
+    private char letter;
 
-  GridElement(char letter) {
-    this.letter = letter;
-  }
-
-  public static GridNode createGridNode(char letter, int positionX, int positionY) {
-    Optional<GridElement> gridElementOpt = Arrays.stream(values())
-        .filter(gridElement -> gridElement.letter == letter)
-        .findFirst();
-    switch (gridElementOpt.orElseThrow(IllegalStateException::new)) {
-      case HOLE:
-        return new Hole(positionX, positionY);
-      case WALL:
-        return new Wall(positionX, positionY);
-      case SPACE:
-        return new Space(positionX, positionY, false, 0);
-      case PICKUP:
-        return new Space(positionX,positionY, true, 0);
-      case EDGE:
-        return new Edge(positionX, positionY, false);
-      case ONE:
-      case TWO:
-      case THREE:
-      case FOUR:
-        return new Space(positionX, positionY, false, Character.getNumericValue(letter));
+    GridElement(char letter) {
+        this.letter = letter;
     }
-    throw new IllegalStateException();
-  }
 
+    public static GridNode createGridNode(char letter, int positionX, int positionY) {
+        Optional<GridElement> gridElementOpt = Arrays.stream(values())
+                .filter(gridElement -> gridElement.letter == letter)
+                .findFirst();
+        switch (gridElementOpt.orElseThrow(IllegalStateException::new)) {
+            case HOLE:
+                return new Hole(positionX, positionY);
+            case WALL:
+                return new Wall(positionX, positionY);
+            case SPACE:
+                return new Space(positionX, positionY, false, 0);
+            case PICKUP:
+                return new Space(positionX, positionY, true, 0);
+            case EDGE:
+                return new Edge(positionX, positionY, false);
+            case ONE:
+            case TWO:
+            case THREE:
+            case FOUR:
+                return new Space(positionX, positionY, false, Character.getNumericValue(letter));
+        }
+        throw new IllegalStateException();
+    }
 }

--- a/src/main/java/ca/ciccc/silverBullet/enums/gameplay/Orientation.java
+++ b/src/main/java/ca/ciccc/silverBullet/enums/gameplay/Orientation.java
@@ -1,5 +1,6 @@
 package ca.ciccc.silverBullet.enums.gameplay;
 
 public enum Orientation {
-    LEFT, RIGHT;
+    LEFT,
+    RIGHT;
 }

--- a/src/main/java/ca/ciccc/silverBullet/enums/gameplay/WaitTime.java
+++ b/src/main/java/ca/ciccc/silverBullet/enums/gameplay/WaitTime.java
@@ -5,28 +5,28 @@ package ca.ciccc.silverBullet.enums.gameplay;
  * commands before the turn passes on. Chosen on the settings screen.
  */
 public enum WaitTime {
-  SHORT("Short", 10),
-  NORMAL("Normal", 20),
-  LONG("Long", 30);
+    SHORT("Short", 10),
+    NORMAL("Normal", 20),
+    LONG("Long", 30);
 
-  /** Pre-selected default on the settings screen. */
-  public static final WaitTime DEFAULT = NORMAL;
+    /** Pre-selected default on the settings screen. */
+    public static final WaitTime DEFAULT = NORMAL;
 
-  private final String label;
-  private final int seconds;
+    private final String label;
+    private final int seconds;
 
-  WaitTime(String label, int seconds) {
-    this.label = label;
-    this.seconds = seconds;
-  }
+    WaitTime(String label, int seconds) {
+        this.label = label;
+        this.seconds = seconds;
+    }
 
-  public int getSeconds() {
-    return seconds;
-  }
+    public int getSeconds() {
+        return seconds;
+    }
 
-  /** Shown in the settings combo box, e.g. {@code "Normal (20s)"}. */
-  @Override
-  public String toString() {
-    return String.format("%s (%ds)", label, seconds);
-  }
+    /** Shown in the settings combo box, e.g. {@code "Normal (20s)"}. */
+    @Override
+    public String toString() {
+        return String.format("%s (%ds)", label, seconds);
+    }
 }

--- a/src/main/java/ca/ciccc/silverBullet/extraScreens/GameOverScreen.java
+++ b/src/main/java/ca/ciccc/silverBullet/extraScreens/GameOverScreen.java
@@ -1,6 +1,5 @@
 package ca.ciccc.silverBullet.extraScreens;
 
-import ca.ciccc.silverBullet.controller.AbstractMenuController;
 import ca.ciccc.silverBullet.controller.MenuController;
 import javafx.scene.control.Button;
 import javafx.scene.layout.Pane;
@@ -10,29 +9,23 @@ import javafx.scene.text.Font;
 import javafx.scene.text.FontWeight;
 import javafx.scene.text.Text;
 
-
 public class GameOverScreen extends Pane {
     Rectangle backgroundImage;
     Text gameOverText;
     Button testBackToMenu;
 
-    public GameOverScreen(int winningPlayerNumber){
+    public GameOverScreen(int winningPlayerNumber) {
 
         this.setStyle("-fx-background-color: rgba(0, 0, 0, 0.7)");
         gameOverText = new Text(String.format("Player %d wins!", winningPlayerNumber));
         testBackToMenu = new Button("Back To Menu");
-        gameOverText.setFont(
-                Font.font("Times New Roman", FontWeight.BOLD, 100)
-        );
+        gameOverText.setFont(Font.font("Times New Roman", FontWeight.BOLD, 100));
 
         gameOverText.setFill(Color.WHITE);
 
-        testBackToMenu.setFont(
-                Font.font("Times New Roman", FontWeight.BOLD, 30)
-        );
+        testBackToMenu.setFont(Font.font("Times New Roman", FontWeight.BOLD, 30));
 
         this.setPrefSize(1000, 1000);
-
 
         gameOverText.setTranslateX(150);
         gameOverText.setTranslateY(300);
@@ -45,6 +38,7 @@ public class GameOverScreen extends Pane {
         this.getChildren().add(testBackToMenu);
 
         testBackToMenu.setOnMouseClicked(mouseEvent -> {
-            MenuController.getInstance().show();});
+            MenuController.getInstance().show();
+        });
     }
 }

--- a/src/main/java/ca/ciccc/silverBullet/extraScreens/InstructionStuff.java
+++ b/src/main/java/ca/ciccc/silverBullet/extraScreens/InstructionStuff.java
@@ -8,8 +8,7 @@ import javafx.scene.shape.Rectangle;
 public class InstructionStuff extends Pane {
     public InstructionStuff() {
         Rectangle leftImage = new Rectangle(180, 160);
-        leftImage.setFill(new ImagePattern(MediaUtil.createImage(
-            "/images/howtoplayL.png")));
+        leftImage.setFill(new ImagePattern(MediaUtil.createImage("/images/howtoplayL.png")));
 
         leftImage.setTranslateX(5);
         leftImage.setTranslateY(425);
@@ -17,8 +16,7 @@ public class InstructionStuff extends Pane {
         this.getChildren().add(leftImage);
 
         Rectangle rightImage = new Rectangle(180, 160);
-        rightImage.setFill(new ImagePattern(MediaUtil.createImage(
-            "/images/howtoplayR.png")));
+        rightImage.setFill(new ImagePattern(MediaUtil.createImage("/images/howtoplayR.png")));
         rightImage.setTranslateX(720);
         rightImage.setTranslateY(425);
         this.getChildren().add(rightImage);

--- a/src/main/java/ca/ciccc/silverBullet/gameBoard/GameScene.java
+++ b/src/main/java/ca/ciccc/silverBullet/gameBoard/GameScene.java
@@ -14,275 +14,264 @@ import javafx.scene.layout.Pane;
 
 public class GameScene extends Pane implements GameSceneEvents {
 
-  private GridBoard gameBoard;
-  private double t = 0;
-  private boolean isExecuting;
-  private int currentActionNumber = 0;
-  private int controllingPlayer = 0;
-  private final int turnDuration;
-  private double turnTimer;
-  TimerDisplay timerDisplay;
-  private boolean isPaused;
-  private Prompter prompter = ModalUtil::alertWithCallback;
-  private Runnable onStop = () -> { };
+    private GridBoard gameBoard;
+    private double t = 0;
+    private boolean isExecuting;
+    private int currentActionNumber = 0;
+    private int controllingPlayer = 0;
+    private final int turnDuration;
+    private double turnTimer;
+    TimerDisplay timerDisplay;
+    private boolean isPaused;
+    private Prompter prompter = ModalUtil::alertWithCallback;
+    private Runnable onStop = () -> {};
 
-  private GameScene(int lvl, int numberOfPlayers, int turnSeconds) {
-    this.turnDuration = turnSeconds;
-    this.turnTimer = turnSeconds;
-    BackgroundGrid backgroundGrid = new BackgroundGrid();
-    gameBoard = new GridBoard(GameSceneCoordinatesEnum.SIZE_BOARD_TILE.get(), GameSceneCoordinatesEnum.SIZE_BOARD_TILE.get(), lvl);
-    gameBoard.setSceneEvents(this);
+    private GameScene(int lvl, int numberOfPlayers, int turnSeconds) {
+        this.turnDuration = turnSeconds;
+        this.turnTimer = turnSeconds;
+        BackgroundGrid backgroundGrid = new BackgroundGrid();
+        gameBoard = new GridBoard(
+                GameSceneCoordinatesEnum.SIZE_BOARD_TILE.get(), GameSceneCoordinatesEnum.SIZE_BOARD_TILE.get(), lvl);
+        gameBoard.setSceneEvents(this);
 
-    this.getChildren().add(backgroundGrid.gridPane);
-    this.getChildren().add(gameBoard.gridBoard);
+        this.getChildren().add(backgroundGrid.gridPane);
+        this.getChildren().add(gameBoard.gridBoard);
 
+        Pane instructionsPane = new InstructionStuff();
+        this.getChildren().add(instructionsPane);
 
-    Pane instructionsPane = new InstructionStuff();
-    this.getChildren().add(instructionsPane);
+        for (int i = 1; i < numberOfPlayers + 1; i++) {
+            GridNode playerNode = gameBoard.getPlayerStartLocation()[i - 1];
 
-    for(int i = 1; i < numberOfPlayers+1; i++){
-      GridNode playerNode = gameBoard.getPlayerStartLocation()[i-1];
-
-      gameBoard.addPlayer(playerNode.getGridX(), playerNode.getGridY(), i);
-    }
-
-    timerDisplay = new TimerDisplay(gameBoard.players);
-
-    if(numberOfPlayers == 4){
-      timerDisplay.setTranslateX(GameSceneCoordinatesEnum.TIMER_DISPLAY_X.get()- 40);
-    }else{
-      timerDisplay.setTranslateX(GameSceneCoordinatesEnum.TIMER_DISPLAY_X.get());
-    }
-
-
-    timerDisplay.setTranslateY(GameSceneCoordinatesEnum.TIMER_DISPLAY_Y.get());
-
-    this.getChildren().add(timerDisplay);
-
-    timerDisplay.setHighlight(0);
-
-    for (int i = 0; i < gameBoard.players.size(); i++) {
-      Player player = gameBoard.players.get(i);
-      ActionCounter ac = player.getPlayerActionCounter();
-
-      ac.adjustActionCounter(gameBoard.players.size(), i);
-
-      ac.setTranslateY(GameSceneCoordinatesEnum.SIZE_BOARD_Y_MAIN.get());
-      this.getChildren().addAll(player.getPlayerNode(), ac);
-    }
-
-    highlightActions(gameBoard.players.get(0));
-
-
-  }
-
-  public static class Builder {
-    private int playerNumber;
-    private int level;
-    private int turnSeconds = 10;
-
-    public Builder player(int playerNumber) {
-      this.playerNumber = playerNumber;
-      return this;
-    }
-
-    public Builder level(int level) {
-      this.level = level;
-      return this;
-    }
-
-    public Builder turnSeconds(int turnSeconds) {
-      this.turnSeconds = turnSeconds;
-      return this;
-    }
-
-    public GameScene build() {
-      return new GameScene(this.level, playerNumber, turnSeconds);
-    }
-
-  }
-
-  @Override
-  public void removePlayerVisuals(Player player) {
-    this.getChildren().remove(player.getPlayerNode());
-    timerDisplay.removePlayerImage(player);
-  }
-
-  @Override
-  public void showGameOver(int playerWhoWon){
-    stopAll();
-    GameOverScreen gameOverScreen = new GameOverScreen(playerWhoWon);
-    this.getChildren().add(gameOverScreen);
-  }
-
-  // Package-private accessor so the turn/planning flow can be smoke-tested.
-  GridBoard getGameBoard() {
-    return gameBoard;
-  }
-
-  // Package-private accessor exposing the countdown for tests.
-  double getTurnTimer() {
-    return turnTimer;
-  }
-
-  // Package-private seam so tests can auto-confirm the turn-flow dialogs.
-  void setPrompter(Prompter prompter) {
-    this.prompter = prompter;
-  }
-
-  /** Injected by the owner to stop the game loop when the game ends. */
-  public void setOnStop(Runnable onStop) {
-    this.onStop = onStop;
-  }
-
-  public void boardUpdate() {
-    if (!isExecuting && !isPaused) {
-
-      if (turnTimer <= 0) {
-        isPaused = true;
-        turnEnd();
-      } else {
-        turnTimer -= 0.016;
-        timerDisplay.timerUpdate(turnTimer);
-      }
-
-    } else if (isExecuting) {
-
-      if (t <= 0) {
-        t = .4;
-        executePlayerActions();
-        currentActionNumber++;
-
-        if (currentActionNumber > 4) {
-          actionEndStep();
+            gameBoard.addPlayer(playerNode.getGridX(), playerNode.getGridY(), i);
         }
-      } else {
-        t -= 0.016;
-      }
 
+        timerDisplay = new TimerDisplay(gameBoard.players);
+
+        if (numberOfPlayers == 4) {
+            timerDisplay.setTranslateX(GameSceneCoordinatesEnum.TIMER_DISPLAY_X.get() - 40);
+        } else {
+            timerDisplay.setTranslateX(GameSceneCoordinatesEnum.TIMER_DISPLAY_X.get());
+        }
+
+        timerDisplay.setTranslateY(GameSceneCoordinatesEnum.TIMER_DISPLAY_Y.get());
+
+        this.getChildren().add(timerDisplay);
+
+        timerDisplay.setHighlight(0);
+
+        for (int i = 0; i < gameBoard.players.size(); i++) {
+            Player player = gameBoard.players.get(i);
+            ActionCounter ac = player.getPlayerActionCounter();
+
+            ac.adjustActionCounter(gameBoard.players.size(), i);
+
+            ac.setTranslateY(GameSceneCoordinatesEnum.SIZE_BOARD_Y_MAIN.get());
+            this.getChildren().addAll(player.getPlayerNode(), ac);
+        }
+
+        highlightActions(gameBoard.players.get(0));
     }
 
+    public static class Builder {
+        private int playerNumber;
+        private int level;
+        private int turnSeconds = 10;
 
-  }
+        public Builder player(int playerNumber) {
+            this.playerNumber = playerNumber;
+            return this;
+        }
 
-  public void onKeyPressed(KeyCode key) {
-    if (isExecuting) {
-      return;
+        public Builder level(int level) {
+            this.level = level;
+            return this;
+        }
+
+        public Builder turnSeconds(int turnSeconds) {
+            this.turnSeconds = turnSeconds;
+            return this;
+        }
+
+        public GameScene build() {
+            return new GameScene(this.level, playerNumber, turnSeconds);
+        }
     }
 
-    if (!gameBoard.areAllFull()) {
-      gameBoard.players
-          .get(controllingPlayer)
-          .addAction(PlayerAction.getActionByKeyCode(key));
-
+    @Override
+    public void removePlayerVisuals(Player player) {
+        this.getChildren().remove(player.getPlayerNode());
+        timerDisplay.removePlayerImage(player);
     }
 
-    if (KeyCode.SPACE.equals(key)) {
-      turnEnd();
+    @Override
+    public void showGameOver(int playerWhoWon) {
+        stopAll();
+        GameOverScreen gameOverScreen = new GameOverScreen(playerWhoWon);
+        this.getChildren().add(gameOverScreen);
     }
 
-  }
-
-  private void executePlayerActions() {
-
-    for (Player p : gameBoard.players) {
-      if (PlayerAction.SHOOT.equals(p.getPlayerActions()[currentActionNumber])) {
-        p.takeAction(currentActionNumber);
-      }
+    // Package-private accessor so the turn/planning flow can be smoke-tested.
+    GridBoard getGameBoard() {
+        return gameBoard;
     }
 
-    for (Player p : gameBoard.players) {
-      if (!PlayerAction.SHOOT.equals(p.getPlayerActions()[currentActionNumber])) {
-        p.takeAction(currentActionNumber);
-      }
+    // Package-private accessor exposing the countdown for tests.
+    double getTurnTimer() {
+        return turnTimer;
     }
 
-    executeMove();
-  }
-
-  private void actionEndStep() {
-
-    for (Player p : gameBoard.players) {
-      p.getPlayerActionCounter().clearActions();
-      p.resetActions();
+    // Package-private seam so tests can auto-confirm the turn-flow dialogs.
+    void setPrompter(Prompter prompter) {
+        this.prompter = prompter;
     }
 
-    isExecuting = false;
-    controllingPlayer = 0;
-    currentActionNumber = 0;
-    isPaused = true;
-    timerDisplay.setHighlight(controllingPlayer);
-    prompter.prompt("Planning Phase", "Move to planning phase?", () -> {isPaused = false;
-      highlightActions(gameBoard.players.get(controllingPlayer));
-    });
-  }
-
-  private void stopAll(){
-    // Defaults to a no-op, so ending the game is safe when no loop is running
-    // (e.g. in tests); the owner injects the real stop via setOnStop.
-    onStop.run();
-  }
-
-  // Package-private so simultaneous-move collision resolution can be tested.
-  void executeMove() {
-    // Snapshot every player's destination, decide all moves at once, then apply
-    // them. Players contending for the same tile collide and none of them move.
-    int[][] targets = new int[gameBoard.players.size()][];
-    for (int i = 0; i < gameBoard.players.size(); i++) {
-      Move move = gameBoard.players.get(i).getTargetMove();
-      targets[i] = move == null ? null : new int[] {move.getMoveX(), move.getMoveY()};
+    /** Injected by the owner to stop the game loop when the game ends. */
+    public void setOnStop(Runnable onStop) {
+        this.onStop = onStop;
     }
 
-    boolean[] canMove = GameLogic.resolveSimultaneousMoves(targets);
-    for (int i = 0; i < gameBoard.players.size(); i++) {
-      if (canMove[i]) {
-        gameBoard.movePlayer(gameBoard.players.get(i));
-      }
+    public void boardUpdate() {
+        if (!isExecuting && !isPaused) {
+
+            if (turnTimer <= 0) {
+                isPaused = true;
+                turnEnd();
+            } else {
+                turnTimer -= 0.016;
+                timerDisplay.timerUpdate(turnTimer);
+            }
+
+        } else if (isExecuting) {
+
+            if (t <= 0) {
+                t = .4;
+                executePlayerActions();
+                currentActionNumber++;
+
+                if (currentActionNumber > 4) {
+                    actionEndStep();
+                }
+            } else {
+                t -= 0.016;
+            }
+        }
     }
 
-    // A move applies only in its own step. Drop any target left unfulfilled by a
-    // collision so it cannot resolve on a later, non-move step. (Players that
-    // moved were already cleared by movePlayer.)
-    gameBoard.players.forEach(player -> player.setTargetMove(null));
-  }
+    public void onKeyPressed(KeyCode key) {
+        if (isExecuting) {
+            return;
+        }
 
-  private void highlightActions(Player playerToHighlight){
-    gameBoard.players.forEach(p->{
-      if(!playerToHighlight.equals(p)){
-        p.getPlayerActionCounter().darkenSelf();
-      } else{
-        p.getPlayerActionCounter().lightenSelf();
-      }
-    });
-  }
+        if (!gameBoard.areAllFull()) {
+            gameBoard.players.get(controllingPlayer).addAction(PlayerAction.getActionByKeyCode(key));
+        }
 
-  private void highlightAllActions(){
-    gameBoard.players.forEach(p->p.getPlayerActionCounter().lightenSelf());
-  }
+        if (KeyCode.SPACE.equals(key)) {
+            turnEnd();
+        }
+    }
 
-  private void turnEnd() {
-    gameBoard.players.get(controllingPlayer).passTurn();
-    isPaused = true;
-    if (!gameBoard.areAllFull()) {
-      controllingPlayer++;
-      highlightActions(gameBoard.players.get(controllingPlayer));
-      timerDisplay.setHighlight(controllingPlayer);
-      prompter.prompt("Next Turn", "Next Player's Turn", () -> {
-        isPaused = false;
-        turnTimer = turnDuration;
-      });
+    private void executePlayerActions() {
 
+        for (Player p : gameBoard.players) {
+            if (PlayerAction.SHOOT.equals(p.getPlayerActions()[currentActionNumber])) {
+                p.takeAction(currentActionNumber);
+            }
+        }
 
-    } else {
-      timerDisplay.highlightAll();
-      prompter.prompt("Execute", "Move to execution?", () -> {
-        turnTimer = turnDuration;
-        currentActionNumber = 0;
+        for (Player p : gameBoard.players) {
+            if (!PlayerAction.SHOOT.equals(p.getPlayerActions()[currentActionNumber])) {
+                p.takeAction(currentActionNumber);
+            }
+        }
+
+        executeMove();
+    }
+
+    private void actionEndStep() {
+
+        for (Player p : gameBoard.players) {
+            p.getPlayerActionCounter().clearActions();
+            p.resetActions();
+        }
+
+        isExecuting = false;
         controllingPlayer = 0;
-        isExecuting = true;
-        isPaused = false;
-        highlightAllActions();
-      });
+        currentActionNumber = 0;
+        isPaused = true;
+        timerDisplay.setHighlight(controllingPlayer);
+        prompter.prompt("Planning Phase", "Move to planning phase?", () -> {
+            isPaused = false;
+            highlightActions(gameBoard.players.get(controllingPlayer));
+        });
     }
-  }
+
+    private void stopAll() {
+        // Defaults to a no-op, so ending the game is safe when no loop is running
+        // (e.g. in tests); the owner injects the real stop via setOnStop.
+        onStop.run();
+    }
+
+    // Package-private so simultaneous-move collision resolution can be tested.
+    void executeMove() {
+        // Snapshot every player's destination, decide all moves at once, then apply
+        // them. Players contending for the same tile collide and none of them move.
+        int[][] targets = new int[gameBoard.players.size()][];
+        for (int i = 0; i < gameBoard.players.size(); i++) {
+            Move move = gameBoard.players.get(i).getTargetMove();
+            targets[i] = move == null ? null : new int[] {move.getMoveX(), move.getMoveY()};
+        }
+
+        boolean[] canMove = GameLogic.resolveSimultaneousMoves(targets);
+        for (int i = 0; i < gameBoard.players.size(); i++) {
+            if (canMove[i]) {
+                gameBoard.movePlayer(gameBoard.players.get(i));
+            }
+        }
+
+        // A move applies only in its own step. Drop any target left unfulfilled by a
+        // collision so it cannot resolve on a later, non-move step. (Players that
+        // moved were already cleared by movePlayer.)
+        gameBoard.players.forEach(player -> player.setTargetMove(null));
+    }
+
+    private void highlightActions(Player playerToHighlight) {
+        gameBoard.players.forEach(p -> {
+            if (!playerToHighlight.equals(p)) {
+                p.getPlayerActionCounter().darkenSelf();
+            } else {
+                p.getPlayerActionCounter().lightenSelf();
+            }
+        });
+    }
+
+    private void highlightAllActions() {
+        gameBoard.players.forEach(p -> p.getPlayerActionCounter().lightenSelf());
+    }
+
+    private void turnEnd() {
+        gameBoard.players.get(controllingPlayer).passTurn();
+        isPaused = true;
+        if (!gameBoard.areAllFull()) {
+            controllingPlayer++;
+            highlightActions(gameBoard.players.get(controllingPlayer));
+            timerDisplay.setHighlight(controllingPlayer);
+            prompter.prompt("Next Turn", "Next Player's Turn", () -> {
+                isPaused = false;
+                turnTimer = turnDuration;
+            });
+
+        } else {
+            timerDisplay.highlightAll();
+            prompter.prompt("Execute", "Move to execution?", () -> {
+                turnTimer = turnDuration;
+                currentActionNumber = 0;
+                controllingPlayer = 0;
+                isExecuting = true;
+                isPaused = false;
+                highlightAllActions();
+            });
+        }
+    }
 }

--- a/src/main/java/ca/ciccc/silverBullet/gameBoard/GameSceneEvents.java
+++ b/src/main/java/ca/ciccc/silverBullet/gameBoard/GameSceneEvents.java
@@ -10,9 +10,9 @@ import ca.ciccc.silverBullet.playerElements.Player;
  */
 public interface GameSceneEvents {
 
-  /** Remove a knocked-out player's visuals (its board node and timer image). */
-  void removePlayerVisuals(Player player);
+    /** Remove a knocked-out player's visuals (its board node and timer image). */
+    void removePlayerVisuals(Player player);
 
-  /** Announce the winner and show the game-over screen. */
-  void showGameOver(int winningPlayerNumber);
+    /** Announce the winner and show the game-over screen. */
+    void showGameOver(int winningPlayerNumber);
 }

--- a/src/main/java/ca/ciccc/silverBullet/gameBoard/GridBoard.java
+++ b/src/main/java/ca/ciccc/silverBullet/gameBoard/GridBoard.java
@@ -7,7 +7,6 @@ import ca.ciccc.silverBullet.logic.GameLogic;
 import ca.ciccc.silverBullet.playerElements.Bullet;
 import ca.ciccc.silverBullet.playerElements.CollisionBullet;
 import ca.ciccc.silverBullet.playerElements.Player;
-import ca.ciccc.silverBullet.utils.ConstUtil;
 import ca.ciccc.silverBullet.utils.ConstUtil.GridBoardSizeEnum;
 import ca.ciccc.silverBullet.utils.LevelFileReadUtil;
 import ca.ciccc.silverBullet.utils.MediaUtil;
@@ -25,230 +24,228 @@ import javafx.util.Duration;
 
 public class GridBoard {
 
-  private GridNode[][] grid;
-  public GridPane gridBoard;
-  public List<Player> players;
-  private GridNode[] playerStartLocation;
-  private int gridSizeX;
-  private int gridSizeY;
-  private GameSceneEvents sceneEvents;
-  private static final String PICKUP_IMAGE_PATH = "/images/Tiles/Pickup.png";
+    private GridNode[][] grid;
+    public GridPane gridBoard;
+    public List<Player> players;
+    private GridNode[] playerStartLocation;
+    private int gridSizeX;
+    private int gridSizeY;
+    private GameSceneEvents sceneEvents;
+    private static final String PICKUP_IMAGE_PATH = "/images/Tiles/Pickup.png";
 
-  GridBoard(int sizeX, int sizeY, int level) {
-    this.generateBoard(sizeX, sizeY, level);
+    GridBoard(int sizeX, int sizeY, int level) {
+        this.generateBoard(sizeX, sizeY, level);
 
-    this.players = new ArrayList<>();
-    this.gridSizeX = sizeX - 1;
-    this.gridSizeY = sizeY - 1;
-  }
-
-  public Move tryMovePlayer(Player playerToMove) {
-    GridNode originGrid =
-        grid[playerToMove.getGridPositionY()][playerToMove.getGridPositionX()];
-
-    if (!originGrid.hasPlayer()) {
-      return null;
+        this.players = new ArrayList<>();
+        this.gridSizeX = sizeX - 1;
+        this.gridSizeY = sizeY - 1;
     }
 
-    int[] destination = GameLogic.moveDestination(
-        originGrid.getGridX(),
-        originGrid.getGridY(),
-        originGrid.getPlayerInSpace().getFacingDirection(),
-        gridSizeX,
-        gridSizeY,
-        (x, y) -> grid[y][x].isCanMoveTo(),
-        (x, y) -> grid[y][x].hasPlayer());
+    public Move tryMovePlayer(Player playerToMove) {
+        GridNode originGrid = grid[playerToMove.getGridPositionY()][playerToMove.getGridPositionX()];
 
-    return destination == null ? null : new Move(destination[0], destination[1]);
-  }
-
-
-  void movePlayer(Player playerToMove) {
-    if (playerToMove.getTargetMove() == null) {
-      return;
-    }
-    TranslateTransition moveTransition = new TranslateTransition();
-
-    GridNode startNode = grid[playerToMove.getGridPositionY()][playerToMove.getGridPositionX()];
-    GridNode targetNode = grid[playerToMove.getTargetMove().getMoveY()][playerToMove.getTargetMove().getMoveX()];
-
-
-    grid[playerToMove.getGridPositionY()][playerToMove.getGridPositionX()].setPlayerInSpace(null);
-    targetNode.setPlayerInSpace(playerToMove);
-
-    playerToMove.setGridPositionX(targetNode.getGridX());
-    playerToMove.setGridPositionY(targetNode.getGridY());
-
-    moveTransition.setFromX(startNode.getScreenX() + GridBoardSizeEnum.SPACE_TARGET_NODE_X.get());
-    moveTransition.setFromY(startNode.getScreenY() + GridBoardSizeEnum.SPACE_TARGET_NODE_Y.get());
-
-    moveTransition.setToX(targetNode.getScreenX() + GridBoardSizeEnum.SPACE_TARGET_NODE_X.get());
-    moveTransition.setToY(targetNode.getScreenY() + GridBoardSizeEnum.SPACE_TARGET_NODE_Y.get());
-
-    moveTransition.setDuration(Duration.seconds(.3));
-
-    moveTransition.setInterpolator(Interpolator.EASE_OUT);
-
-    moveTransition.setNode(playerToMove.getPlayerNode());
-
-    moveTransition.play();
-
-    if (targetNode.isHasPickup()){
-      if(playerToMove.getNumberOfShots() < 3){
-
-        playerToMove.addShot();
-        pickupAquired(targetNode);
-      }
-    }
-
-    playerToMove.setTargetMove(null);
-  }
-
-  private void generateBoard(int sizeX, int sizeY, int levelNumber) {
-    this.grid = new GridNode[sizeY][sizeX];
-    this.playerStartLocation = new GridNode[4];
-    this.gridBoard = new GridPane();
-
-    char[][] imageToPrint = LevelFileReadUtil.getLevelMapAry(levelNumber);
-
-    for (int i = 0; i < sizeY; i++) {
-      for (int j = 0; j < sizeX; j++) {
-        GridNode nodeToAdd = GridElement.createGridNode(imageToPrint[i][j], j, i);
-        this.gridBoard.add(nodeToAdd.getImage(), j, i);
-        if(nodeToAdd.getPlayerStartPosition() > 0){
-          this.playerStartLocation[nodeToAdd.getPlayerStartPosition()-1] = nodeToAdd;
+        if (!originGrid.hasPlayer()) {
+            return null;
         }
-        this.grid[i][j] = nodeToAdd;
-        nodeToAdd.setGridX(j);
-        nodeToAdd.setGridY(i);
-      }
+
+        int[] destination = GameLogic.moveDestination(
+                originGrid.getGridX(),
+                originGrid.getGridY(),
+                originGrid.getPlayerInSpace().getFacingDirection(),
+                gridSizeX,
+                gridSizeY,
+                (x, y) -> grid[y][x].isCanMoveTo(),
+                (x, y) -> grid[y][x].hasPlayer());
+
+        return destination == null ? null : new Move(destination[0], destination[1]);
     }
 
-    gridBoard.setTranslateX(GridBoardSizeEnum.BOARD_POSITION_X.get());
-    gridBoard.setTranslateY(GridBoardSizeEnum.BOARD_POSITION_Y.get());
-
-    for (int i = 0; i < sizeY; i++) {
-      for (int j = 0; j < sizeX; j++) {
-        grid[j][i].setScreenX((i * GridBoardSizeEnum.TILE_SIZE.get()) + GridBoardSizeEnum.BOARD_POSITION_X.get());
-        grid[j][i].setScreenY((j * GridBoardSizeEnum.TILE_SIZE.get()) + GridBoardSizeEnum.BOARD_POSITION_Y.get());
-
-        if(grid[j][i].isHasPickup()){
-          Image pickupImage = MediaUtil.createImage(PICKUP_IMAGE_PATH);
-          Node pickupNode = new Circle(20, new ImagePattern(pickupImage));
-          pickupNode.setTranslateX(grid[j][i].getScreenX() - GridBoardSizeEnum.BOARD_POSITION_X.get() + 10);
-          pickupNode.setTranslateY(grid[j][i].getScreenY() - GridBoardSizeEnum.BOARD_POSITION_Y.get());
-          grid[j][i].setPickupImage(pickupNode);
-          gridBoard.getChildren().add(pickupNode);
+    void movePlayer(Player playerToMove) {
+        if (playerToMove.getTargetMove() == null) {
+            return;
         }
-      }
-    }
-  }
+        TranslateTransition moveTransition = new TranslateTransition();
 
-  Player addPlayer(int gridX, int gridY, int playerNumber) {
-    GridNode targetNode = grid[gridY][gridX];
-    if (targetNode.hasPlayer()) {
+        GridNode startNode = grid[playerToMove.getGridPositionY()][playerToMove.getGridPositionX()];
+        GridNode targetNode = grid[playerToMove.getTargetMove().getMoveY()][
+                playerToMove.getTargetMove().getMoveX()];
 
-      return null;
-    }
+        grid[playerToMove.getGridPositionY()][playerToMove.getGridPositionX()].setPlayerInSpace(null);
+        targetNode.setPlayerInSpace(playerToMove);
 
-    Player playerToAdd;
-  if(gridY > gridSizeY / 2){
-    playerToAdd =
-        new Player(3, playerNumber, gridX, gridY, Directions.NORTH, this);
-  } else {
-    playerToAdd =
-            new Player(3, playerNumber, gridX, gridY, Directions.SOUTH, this);
-  }
-    players.add(playerToAdd);
-    targetNode.setPlayerInSpace(playerToAdd);
+        playerToMove.setGridPositionX(targetNode.getGridX());
+        playerToMove.setGridPositionY(targetNode.getGridY());
 
-    playerToAdd.getPlayerNode().setTranslateX(targetNode.getScreenX() + GridBoardSizeEnum.SPACE_TARGET_NODE_X.get());
-    playerToAdd.getPlayerNode().setTranslateY(targetNode.getScreenY() + GridBoardSizeEnum.SPACE_TARGET_NODE_Y.get());
+        moveTransition.setFromX(startNode.getScreenX() + GridBoardSizeEnum.SPACE_TARGET_NODE_X.get());
+        moveTransition.setFromY(startNode.getScreenY() + GridBoardSizeEnum.SPACE_TARGET_NODE_Y.get());
 
-    return playerToAdd;
-  }
+        moveTransition.setToX(targetNode.getScreenX() + GridBoardSizeEnum.SPACE_TARGET_NODE_X.get());
+        moveTransition.setToY(targetNode.getScreenY() + GridBoardSizeEnum.SPACE_TARGET_NODE_Y.get());
 
-  // Package-private (not private) so the trajectory can be verified against a
-  // real board in tests.
-  Move tryShoot(Player playerShooting) {
-    if (!playerShooting.isHasShot()) {
-      return null;
-    }
+        moveTransition.setDuration(Duration.seconds(.3));
 
-    int[] endpoint = GameLogic.shotEndpoint(
-        playerShooting.getGridPositionX(),
-        playerShooting.getGridPositionY(),
-        playerShooting.getFacingDirection(),
-        gridSizeX,
-        gridSizeY,
-        (x, y) -> grid[y][x].isCanMoveTo());
+        moveTransition.setInterpolator(Interpolator.EASE_OUT);
 
-    return endpoint == null ? null : new Move(endpoint[0], endpoint[1]);
-  }
+        moveTransition.setNode(playerToMove.getPlayerNode());
 
-  void setSceneEvents(GameSceneEvents sceneEvents) {
-    this.sceneEvents = sceneEvents;
-  }
+        moveTransition.play();
 
-  public void removePlayer(Player playerToRemove) {
-    sceneEvents.removePlayerVisuals(playerToRemove);
-    playerToRemove.getPlayerActionCounter().blackout();
+        if (targetNode.isHasPickup()) {
+            if (playerToMove.getNumberOfShots() < 3) {
 
-    detachPlayerFromBoard(playerToRemove)
-        .ifPresent(sceneEvents::showGameOver);
-  }
+                playerToMove.addShot();
+                pickupAquired(targetNode);
+            }
+        }
 
-  /**
-   * Clears the tile the player occupies and drops it from the roster. Contains
-   * no rendering side effects, so it can be unit-tested against a real board.
-   *
-   * @return the sole survivor's player number when only one player remains
-   *     (the game-over condition), otherwise empty
-   */
-  OptionalInt detachPlayerFromBoard(Player playerToRemove) {
-    getNodeFromGrid(playerToRemove.getGridPositionX(), playerToRemove.getGridPositionY())
-        .setPlayerInSpace(null);
-    players.remove(playerToRemove);
-    return players.size() == 1
-        ? OptionalInt.of(players.get(0).getPlayerNumber())
-        : OptionalInt.empty();
-  }
-
-  private void pickupAquired(GridNode node){
-    node.setHasPickup(false);
-    gridBoard.getChildren().remove(node.getPickupImage());
-  }
-
-  public void shootBullet(Player player) {
-    Move finalLocation = tryShoot(player);
-    if (finalLocation == null) {
-      return;
+        playerToMove.setTargetMove(null);
     }
 
-    Bullet bulletToShoot = new Bullet(
-            new Move(player.getGridPositionX(), player.getGridPositionY()),
-            finalLocation,
-            player,
-            this
-    );
+    private void generateBoard(int sizeX, int sizeY, int levelNumber) {
+        this.grid = new GridNode[sizeY][sizeX];
+        this.playerStartLocation = new GridNode[4];
+        this.gridBoard = new GridPane();
 
-    gridBoard.getChildren().add(bulletToShoot);
-    gridBoard.getChildren().add(new CollisionBullet(new Move(player.getGridPositionX(), player.getGridPositionY()),
-            finalLocation,
-            player,
-            bulletToShoot,
-            this));
-  }
+        char[][] imageToPrint = LevelFileReadUtil.getLevelMapAry(levelNumber);
 
-  GridNode[] getPlayerStartLocation() {
-    return playerStartLocation;
-  }
+        for (int i = 0; i < sizeY; i++) {
+            for (int j = 0; j < sizeX; j++) {
+                GridNode nodeToAdd = GridElement.createGridNode(imageToPrint[i][j], j, i);
+                this.gridBoard.add(nodeToAdd.getImage(), j, i);
+                if (nodeToAdd.getPlayerStartPosition() > 0) {
+                    this.playerStartLocation[nodeToAdd.getPlayerStartPosition() - 1] = nodeToAdd;
+                }
+                this.grid[i][j] = nodeToAdd;
+                nodeToAdd.setGridX(j);
+                nodeToAdd.setGridY(i);
+            }
+        }
 
-  public GridNode getNodeFromGrid(int x, int y) {
-    return grid[y][x];
-  }
+        gridBoard.setTranslateX(GridBoardSizeEnum.BOARD_POSITION_X.get());
+        gridBoard.setTranslateY(GridBoardSizeEnum.BOARD_POSITION_Y.get());
 
-  boolean areAllFull() {
-    return players.stream().allMatch(Player::isActionsFull);
-  }
+        for (int i = 0; i < sizeY; i++) {
+            for (int j = 0; j < sizeX; j++) {
+                grid[j][i].setScreenX(
+                        (i * GridBoardSizeEnum.TILE_SIZE.get()) + GridBoardSizeEnum.BOARD_POSITION_X.get());
+                grid[j][i].setScreenY(
+                        (j * GridBoardSizeEnum.TILE_SIZE.get()) + GridBoardSizeEnum.BOARD_POSITION_Y.get());
+
+                if (grid[j][i].isHasPickup()) {
+                    Image pickupImage = MediaUtil.createImage(PICKUP_IMAGE_PATH);
+                    Node pickupNode = new Circle(20, new ImagePattern(pickupImage));
+                    pickupNode.setTranslateX(grid[j][i].getScreenX() - GridBoardSizeEnum.BOARD_POSITION_X.get() + 10);
+                    pickupNode.setTranslateY(grid[j][i].getScreenY() - GridBoardSizeEnum.BOARD_POSITION_Y.get());
+                    grid[j][i].setPickupImage(pickupNode);
+                    gridBoard.getChildren().add(pickupNode);
+                }
+            }
+        }
+    }
+
+    Player addPlayer(int gridX, int gridY, int playerNumber) {
+        GridNode targetNode = grid[gridY][gridX];
+        if (targetNode.hasPlayer()) {
+
+            return null;
+        }
+
+        Player playerToAdd;
+        if (gridY > gridSizeY / 2) {
+            playerToAdd = new Player(3, playerNumber, gridX, gridY, Directions.NORTH, this);
+        } else {
+            playerToAdd = new Player(3, playerNumber, gridX, gridY, Directions.SOUTH, this);
+        }
+        players.add(playerToAdd);
+        targetNode.setPlayerInSpace(playerToAdd);
+
+        playerToAdd
+                .getPlayerNode()
+                .setTranslateX(targetNode.getScreenX() + GridBoardSizeEnum.SPACE_TARGET_NODE_X.get());
+        playerToAdd
+                .getPlayerNode()
+                .setTranslateY(targetNode.getScreenY() + GridBoardSizeEnum.SPACE_TARGET_NODE_Y.get());
+
+        return playerToAdd;
+    }
+
+    // Package-private (not private) so the trajectory can be verified against a
+    // real board in tests.
+    Move tryShoot(Player playerShooting) {
+        if (!playerShooting.isHasShot()) {
+            return null;
+        }
+
+        int[] endpoint = GameLogic.shotEndpoint(
+                playerShooting.getGridPositionX(),
+                playerShooting.getGridPositionY(),
+                playerShooting.getFacingDirection(),
+                gridSizeX,
+                gridSizeY,
+                (x, y) -> grid[y][x].isCanMoveTo());
+
+        return endpoint == null ? null : new Move(endpoint[0], endpoint[1]);
+    }
+
+    void setSceneEvents(GameSceneEvents sceneEvents) {
+        this.sceneEvents = sceneEvents;
+    }
+
+    public void removePlayer(Player playerToRemove) {
+        sceneEvents.removePlayerVisuals(playerToRemove);
+        playerToRemove.getPlayerActionCounter().blackout();
+
+        detachPlayerFromBoard(playerToRemove).ifPresent(sceneEvents::showGameOver);
+    }
+
+    /**
+     * Clears the tile the player occupies and drops it from the roster. Contains
+     * no rendering side effects, so it can be unit-tested against a real board.
+     *
+     * @return the sole survivor's player number when only one player remains
+     *     (the game-over condition), otherwise empty
+     */
+    OptionalInt detachPlayerFromBoard(Player playerToRemove) {
+        getNodeFromGrid(playerToRemove.getGridPositionX(), playerToRemove.getGridPositionY())
+                .setPlayerInSpace(null);
+        players.remove(playerToRemove);
+        return players.size() == 1 ? OptionalInt.of(players.get(0).getPlayerNumber()) : OptionalInt.empty();
+    }
+
+    private void pickupAquired(GridNode node) {
+        node.setHasPickup(false);
+        gridBoard.getChildren().remove(node.getPickupImage());
+    }
+
+    public void shootBullet(Player player) {
+        Move finalLocation = tryShoot(player);
+        if (finalLocation == null) {
+            return;
+        }
+
+        Bullet bulletToShoot =
+                new Bullet(new Move(player.getGridPositionX(), player.getGridPositionY()), finalLocation, player, this);
+
+        gridBoard.getChildren().add(bulletToShoot);
+        gridBoard
+                .getChildren()
+                .add(new CollisionBullet(
+                        new Move(player.getGridPositionX(), player.getGridPositionY()),
+                        finalLocation,
+                        player,
+                        bulletToShoot,
+                        this));
+    }
+
+    GridNode[] getPlayerStartLocation() {
+        return playerStartLocation;
+    }
+
+    public GridNode getNodeFromGrid(int x, int y) {
+        return grid[y][x];
+    }
+
+    boolean areAllFull() {
+        return players.stream().allMatch(Player::isActionsFull);
+    }
 }

--- a/src/main/java/ca/ciccc/silverBullet/gameBoard/Move.java
+++ b/src/main/java/ca/ciccc/silverBullet/gameBoard/Move.java
@@ -1,6 +1,6 @@
 package ca.ciccc.silverBullet.gameBoard;
 
-public class Move{
+public class Move {
 
     private int moveX;
     private int moveY;
@@ -12,16 +12,17 @@ public class Move{
 
     @Override
     public boolean equals(Object obj) {
-        if (!(obj instanceof  Move)) {
+        if (!(obj instanceof Move)) {
             return false;
         }
-        Move otherMove = (Move)obj;
+        Move otherMove = (Move) obj;
         return (moveX == otherMove.moveX && moveY == otherMove.moveY);
     }
 
     public int getMoveX() {
         return moveX;
     }
+
     public int getMoveY() {
         return moveY;
     }

--- a/src/main/java/ca/ciccc/silverBullet/gameBoard/Prompter.java
+++ b/src/main/java/ca/ciccc/silverBullet/gameBoard/Prompter.java
@@ -10,5 +10,5 @@ package ca.ciccc.silverBullet.gameBoard;
 @FunctionalInterface
 public interface Prompter {
 
-  void prompt(String title, String message, Runnable onConfirm);
+    void prompt(String title, String message, Runnable onConfirm);
 }

--- a/src/main/java/ca/ciccc/silverBullet/gameBoard/TimerDisplay.java
+++ b/src/main/java/ca/ciccc/silverBullet/gameBoard/TimerDisplay.java
@@ -20,84 +20,84 @@ import javafx.scene.text.Text;
 
 class TimerDisplay extends HBox {
 
-  private Text timerText;
-  private Circle[] playerImages;
+    private Text timerText;
+    private Circle[] playerImages;
 
-  TimerDisplay(List<Player> players) {
+    TimerDisplay(List<Player> players) {
 
-    playerImages = new Circle[players.size()];
-    for (int i = 0; i < players.size(); i++) {
-      playerImages[i] = ((Circle) players.get(i).getPlayerNode());
-    }
-
-//        this.setBackground(new Background(new BackgroundFill(Color.SADDLEBROWN, new CornerRadii(4), Insets.EMPTY)));
-    Image image = MediaUtil.createImage("/images/Woodboard.png");
-    this.setBackground(new Background(
-        new BackgroundImage(image, BackgroundRepeat.NO_REPEAT, BackgroundRepeat.NO_REPEAT,
-            BackgroundPosition.DEFAULT, BackgroundSize.DEFAULT)));
-
-    this.setPadding(new Insets(10));
-    double currentTime = 0;
-    timerText = new Text();
-    timerText.setText(doubleToTime(currentTime));
-    timerText.setFill(Color.WHITE);
-    timerText.setFont(
-        Font.font("Times New Roman", FontWeight.BOLD, 20)
-    );
-    for (int i = 0; i < playerImages.length; i++) {
-      if (i == playerImages.length / 2) {
-        getChildren().add(timerText);
-      }
-      Circle imageToAdd = new Circle(20, ((Circle) playerImages[i]).getFill());
-      playerImages[i] = imageToAdd;
-      getChildren().add(imageToAdd);
-
-    }
-  }
-
-  private String doubleToTime(double d) {
-    int minutes = (int) d / (60);
-    int seconds = (int) d % 60;
-    return String.format("%d:%02d", minutes, seconds);
-
-  }
-
-  void timerUpdate(double d) {
-    timerText.setText(doubleToTime(d));
-  }
-
-  void removePlayerImage(Player playerToRemove) {
-    ColorAdjust darken = new ColorAdjust();
-    darken.setBrightness(-.85);
-    playerImages[playerToRemove.getPlayerNumber() - 1].setEffect(darken);
-    playerImages[playerToRemove.getPlayerNumber() - 1] = null;
-  }
-
-  void setHighlight(int playerNumber) {
-    Circle imageToCheck = playerImages[playerNumber];
-    ColorAdjust darken = new ColorAdjust();
-    darken.setBrightness(-.4);
-    ColorAdjust lighten = new ColorAdjust();
-    lighten.setBrightness(0);
-    imageToCheck.setEffect(lighten);
-
-    for (Circle playerImage : playerImages) {
-      if (playerImage != null) {
-        if (!playerImage.equals(imageToCheck)) {
-          playerImage.setEffect(darken);
+        playerImages = new Circle[players.size()];
+        for (int i = 0; i < players.size(); i++) {
+            playerImages[i] = ((Circle) players.get(i).getPlayerNode());
         }
-      }
-    }
-  }
 
-  void highlightAll() {
-    ColorAdjust lighten = new ColorAdjust();
-    lighten.setBrightness(0);
+        //        this.setBackground(new Background(new BackgroundFill(Color.SADDLEBROWN, new CornerRadii(4),
+        // Insets.EMPTY)));
+        Image image = MediaUtil.createImage("/images/Woodboard.png");
+        this.setBackground(new Background(new BackgroundImage(
+                image,
+                BackgroundRepeat.NO_REPEAT,
+                BackgroundRepeat.NO_REPEAT,
+                BackgroundPosition.DEFAULT,
+                BackgroundSize.DEFAULT)));
 
-    for (Circle playerImage : playerImages) {
-      if (playerImage != null) {
-        playerImage.setEffect(lighten);
-      }
+        this.setPadding(new Insets(10));
+        double currentTime = 0;
+        timerText = new Text();
+        timerText.setText(doubleToTime(currentTime));
+        timerText.setFill(Color.WHITE);
+        timerText.setFont(Font.font("Times New Roman", FontWeight.BOLD, 20));
+        for (int i = 0; i < playerImages.length; i++) {
+            if (i == playerImages.length / 2) {
+                getChildren().add(timerText);
+            }
+            Circle imageToAdd = new Circle(20, ((Circle) playerImages[i]).getFill());
+            playerImages[i] = imageToAdd;
+            getChildren().add(imageToAdd);
+        }
     }
-  }
+
+    private String doubleToTime(double d) {
+        int minutes = (int) d / (60);
+        int seconds = (int) d % 60;
+        return String.format("%d:%02d", minutes, seconds);
+    }
+
+    void timerUpdate(double d) {
+        timerText.setText(doubleToTime(d));
+    }
+
+    void removePlayerImage(Player playerToRemove) {
+        ColorAdjust darken = new ColorAdjust();
+        darken.setBrightness(-.85);
+        playerImages[playerToRemove.getPlayerNumber() - 1].setEffect(darken);
+        playerImages[playerToRemove.getPlayerNumber() - 1] = null;
+    }
+
+    void setHighlight(int playerNumber) {
+        Circle imageToCheck = playerImages[playerNumber];
+        ColorAdjust darken = new ColorAdjust();
+        darken.setBrightness(-.4);
+        ColorAdjust lighten = new ColorAdjust();
+        lighten.setBrightness(0);
+        imageToCheck.setEffect(lighten);
+
+        for (Circle playerImage : playerImages) {
+            if (playerImage != null) {
+                if (!playerImage.equals(imageToCheck)) {
+                    playerImage.setEffect(darken);
+                }
+            }
+        }
+    }
+
+    void highlightAll() {
+        ColorAdjust lighten = new ColorAdjust();
+        lighten.setBrightness(0);
+
+        for (Circle playerImage : playerImages) {
+            if (playerImage != null) {
+                playerImage.setEffect(lighten);
+            }
+        }
+    }
 }

--- a/src/main/java/ca/ciccc/silverBullet/gridNodes/Edge.java
+++ b/src/main/java/ca/ciccc/silverBullet/gridNodes/Edge.java
@@ -6,42 +6,34 @@ import javafx.scene.shape.Rectangle;
 
 public class Edge extends GridNode {
 
-  public Edge(int gridx, int gridy, boolean hasPickup) {
+    public Edge(int gridx, int gridy, boolean hasPickup) {
 
-    this.gridX = gridx;
-    this.gridY = gridy;
-    name = "Edge";
-    canMoveTo = true;
-    this.hasPickup = hasPickup;
-    image = new Rectangle(60, 60);
-    if (gridx == 0 && gridy != 0 && gridy != 8) {
-      ((Rectangle) image).setFill(
-          new ImagePattern(MediaUtil.createImage("/images/Tiles/Edges/TileEdgesideL.png")));
-    } else if (gridx == 8 && gridy != 0 && gridy != 8) {
-      ((Rectangle) image).setFill(
-          new ImagePattern(MediaUtil.createImage("/images/Tiles/Edges/TileEdgesideR.png")));
-    } else if (gridx != 0 && gridy == 0 && gridx != 8) {
-      ((Rectangle) image).setFill(
-          new ImagePattern(MediaUtil.createImage("/images/Tiles/Edges/TileEdgesideU.png")));
-    } else if (gridx != 0 && gridy == 8 && gridx != 8) {
-      ((Rectangle) image).setFill(
-          new ImagePattern(MediaUtil.createImage("/images/Tiles/Edges/TileEdgesideD.png")));
-    } else if (gridx == 0 && gridy == 0) {
-      ((Rectangle) image)
-          .setFill(new ImagePattern(MediaUtil.createImage("/images/Tiles/Edges/TileEdgeLU.png")));
-    } else if (gridx == 0 && gridy == 8) {
-      ((Rectangle) image)
-          .setFill(new ImagePattern(MediaUtil.createImage("/images/Tiles/Edges/TileEdgeLD.png")));
-    } else if (gridx == 8 && gridy == 0) {
-      ((Rectangle) image)
-          .setFill(new ImagePattern(MediaUtil.createImage("/images/Tiles/Edges/TileEdgeRU.png")));
-    } else if (gridx == 8 && gridy == 8) {
-      ((Rectangle) image)
-          .setFill(new ImagePattern(MediaUtil.createImage("/images/Tiles/Edges/TileEdgeRD.png")));
-
+        this.gridX = gridx;
+        this.gridY = gridy;
+        name = "Edge";
+        canMoveTo = true;
+        this.hasPickup = hasPickup;
+        image = new Rectangle(60, 60);
+        if (gridx == 0 && gridy != 0 && gridy != 8) {
+            ((Rectangle) image)
+                    .setFill(new ImagePattern(MediaUtil.createImage("/images/Tiles/Edges/TileEdgesideL.png")));
+        } else if (gridx == 8 && gridy != 0 && gridy != 8) {
+            ((Rectangle) image)
+                    .setFill(new ImagePattern(MediaUtil.createImage("/images/Tiles/Edges/TileEdgesideR.png")));
+        } else if (gridx != 0 && gridy == 0 && gridx != 8) {
+            ((Rectangle) image)
+                    .setFill(new ImagePattern(MediaUtil.createImage("/images/Tiles/Edges/TileEdgesideU.png")));
+        } else if (gridx != 0 && gridy == 8 && gridx != 8) {
+            ((Rectangle) image)
+                    .setFill(new ImagePattern(MediaUtil.createImage("/images/Tiles/Edges/TileEdgesideD.png")));
+        } else if (gridx == 0 && gridy == 0) {
+            ((Rectangle) image).setFill(new ImagePattern(MediaUtil.createImage("/images/Tiles/Edges/TileEdgeLU.png")));
+        } else if (gridx == 0 && gridy == 8) {
+            ((Rectangle) image).setFill(new ImagePattern(MediaUtil.createImage("/images/Tiles/Edges/TileEdgeLD.png")));
+        } else if (gridx == 8 && gridy == 0) {
+            ((Rectangle) image).setFill(new ImagePattern(MediaUtil.createImage("/images/Tiles/Edges/TileEdgeRU.png")));
+        } else if (gridx == 8 && gridy == 8) {
+            ((Rectangle) image).setFill(new ImagePattern(MediaUtil.createImage("/images/Tiles/Edges/TileEdgeRD.png")));
+        }
     }
-  }
-
-
 }
-

--- a/src/main/java/ca/ciccc/silverBullet/gridNodes/GridNode.java
+++ b/src/main/java/ca/ciccc/silverBullet/gridNodes/GridNode.java
@@ -6,120 +6,120 @@ import javafx.scene.Node;
 
 public abstract class GridNode {
 
-  static final int WIDTH = 60;
-  static final int HEIGHT = 60;
+    static final int WIDTH = 60;
+    static final int HEIGHT = 60;
 
-  int gridX;
-  int gridY;
-  protected String name;
+    int gridX;
+    int gridY;
+    protected String name;
 
-  private double screenX;
-  private double screenY;
+    private double screenX;
+    private double screenY;
 
-  boolean canMoveTo;
+    boolean canMoveTo;
 
-  boolean canShoot;
+    boolean canShoot;
 
-  boolean hasPickup;
+    boolean hasPickup;
 
-  private Player playerInSpace = null;
+    private Player playerInSpace = null;
 
-  Random random = new Random();
+    Random random = new Random();
 
-  protected Node image;
-  private Node pickupImage;
+    protected Node image;
+    private Node pickupImage;
 
-  int playerStartPosition = 0;
+    int playerStartPosition = 0;
 
-  public void setPickupImage(Node pickupImage) {
-    this.pickupImage = pickupImage;
-  }
+    public void setPickupImage(Node pickupImage) {
+        this.pickupImage = pickupImage;
+    }
 
-  public Node getPickupImage() {
-    return pickupImage;
-  }
+    public Node getPickupImage() {
+        return pickupImage;
+    }
 
-  public int getPlayerStartPosition() {
-    return playerStartPosition;
-  }
+    public int getPlayerStartPosition() {
+        return playerStartPosition;
+    }
 
-  public boolean hasPlayer() {
-    return playerInSpace != null;
-  }
+    public boolean hasPlayer() {
+        return playerInSpace != null;
+    }
 
-  public Player getPlayerInSpace() {
-    return playerInSpace;
-  }
+    public Player getPlayerInSpace() {
+        return playerInSpace;
+    }
 
-  public void setPlayerInSpace(Player playerInSpace) {
-    this.playerInSpace = playerInSpace;
-  }
+    public void setPlayerInSpace(Player playerInSpace) {
+        this.playerInSpace = playerInSpace;
+    }
 
-  public int getGridX() {
-    return gridX;
-  }
+    public int getGridX() {
+        return gridX;
+    }
 
-  public void setGridX(int gridX) {
-    this.gridX = gridX;
-  }
+    public void setGridX(int gridX) {
+        this.gridX = gridX;
+    }
 
-  public int getGridY() {
-    return gridY;
-  }
+    public int getGridY() {
+        return gridY;
+    }
 
-  public void setGridY(int gridY) {
-    this.gridY = gridY;
-  }
+    public void setGridY(int gridY) {
+        this.gridY = gridY;
+    }
 
-  public String getName() {
-    return name;
-  }
+    public String getName() {
+        return name;
+    }
 
-  public void setName(String name) {
-    this.name = name;
-  }
+    public void setName(String name) {
+        this.name = name;
+    }
 
-  public double getScreenX() {
-    return screenX;
-  }
+    public double getScreenX() {
+        return screenX;
+    }
 
-  public void setScreenX(int screenX) {
-    this.screenX = screenX;
-  }
+    public void setScreenX(int screenX) {
+        this.screenX = screenX;
+    }
 
-  public double getScreenY() {
-    return screenY;
-  }
+    public double getScreenY() {
+        return screenY;
+    }
 
-  public void setScreenY(int screenY) {
-    this.screenY = screenY;
-  }
+    public void setScreenY(int screenY) {
+        this.screenY = screenY;
+    }
 
-  public Node getImage() {
-    return image;
-  }
+    public Node getImage() {
+        return image;
+    }
 
-  public void setImage(Node image) {
-    this.image = image;
-  }
+    public void setImage(Node image) {
+        this.image = image;
+    }
 
-  public boolean isCanMoveTo() {
-    return canMoveTo;
-  }
+    public boolean isCanMoveTo() {
+        return canMoveTo;
+    }
 
-  public boolean isCanShoot() {
-    return canShoot;
-  }
+    public boolean isCanShoot() {
+        return canShoot;
+    }
 
-  public void setCanShoot(boolean canShoot) {
-    this.canShoot = canShoot;
-  }
+    public void setCanShoot(boolean canShoot) {
+        this.canShoot = canShoot;
+    }
 
-  public boolean isHasPickup() {
-    return hasPickup;
-  }
+    public boolean isHasPickup() {
+        return hasPickup;
+    }
 
-  public void setHasPickup(boolean hasPickup) {
-    this.hasPickup = hasPickup;
-  }
+    public void setHasPickup(boolean hasPickup) {
+        this.hasPickup = hasPickup;
+    }
 }

--- a/src/main/java/ca/ciccc/silverBullet/gridNodes/Hole.java
+++ b/src/main/java/ca/ciccc/silverBullet/gridNodes/Hole.java
@@ -5,15 +5,15 @@ import javafx.scene.paint.ImagePattern;
 import javafx.scene.shape.Rectangle;
 
 public class Hole extends GridNode {
-  private final static String FILE_PATH = "/images/Hole.png";
+    private static final String FILE_PATH = "/images/Hole.png";
 
-  public Hole(int gridx, int gridy) {
-    this.gridX = gridx;
-    this.gridY = gridy;
-    name = "Hole";
-    canMoveTo = false;
-    canShoot = true;
-    image = new Rectangle(WIDTH, HEIGHT);
-    ((Rectangle) image).setFill(new ImagePattern(MediaUtil.createImage(FILE_PATH)));
-  }
+    public Hole(int gridx, int gridy) {
+        this.gridX = gridx;
+        this.gridY = gridy;
+        name = "Hole";
+        canMoveTo = false;
+        canShoot = true;
+        image = new Rectangle(WIDTH, HEIGHT);
+        ((Rectangle) image).setFill(new ImagePattern(MediaUtil.createImage(FILE_PATH)));
+    }
 }

--- a/src/main/java/ca/ciccc/silverBullet/gridNodes/Space.java
+++ b/src/main/java/ca/ciccc/silverBullet/gridNodes/Space.java
@@ -5,20 +5,20 @@ import javafx.scene.paint.ImagePattern;
 import javafx.scene.shape.Rectangle;
 
 public class Space extends GridNode {
-  private final static String FILE_PATH = "/images/Tiles/Tile%s.png";
+    private static final String FILE_PATH = "/images/Tiles/Tile%s.png";
 
-  public Space(int gridx, int gridy, boolean hasPickup, int playerStart) {
-    this.gridX = gridx;
-    this.gridY = gridy;
-    name = "Space";
-    canMoveTo = true;
-    canShoot = true;
-    this.hasPickup = hasPickup;
+    public Space(int gridx, int gridy, boolean hasPickup, int playerStart) {
+        this.gridX = gridx;
+        this.gridY = gridy;
+        name = "Space";
+        canMoveTo = true;
+        canShoot = true;
+        this.hasPickup = hasPickup;
 
-    playerStartPosition = playerStart;
+        playerStartPosition = playerStart;
 
-    image = new Rectangle(WIDTH, HEIGHT);
-    int n = random.nextInt(4) + 1;
-    ((Rectangle) image).setFill(new ImagePattern(MediaUtil.createImage(String.format(FILE_PATH, n))));
-  }
+        image = new Rectangle(WIDTH, HEIGHT);
+        int n = random.nextInt(4) + 1;
+        ((Rectangle) image).setFill(new ImagePattern(MediaUtil.createImage(String.format(FILE_PATH, n))));
+    }
 }

--- a/src/main/java/ca/ciccc/silverBullet/gridNodes/Wall.java
+++ b/src/main/java/ca/ciccc/silverBullet/gridNodes/Wall.java
@@ -5,16 +5,15 @@ import javafx.scene.paint.ImagePattern;
 import javafx.scene.shape.Rectangle;
 
 public class Wall extends GridNode {
-  private final static String FILE_PATH = "/images/Tiles/TileRock%s.png";
+    private static final String FILE_PATH = "/images/Tiles/TileRock%s.png";
 
-  public Wall(int gridx, int gridy) {
-    this.gridX = gridx;
-    this.gridY = gridy;
-    name = "Wall";
-    canMoveTo = false;
-    canShoot = false;
-    image = new Rectangle(WIDTH, HEIGHT);
-    ((Rectangle) image).setFill(new ImagePattern(MediaUtil.createImage(String.format(FILE_PATH, 1))));
-  }
-
+    public Wall(int gridx, int gridy) {
+        this.gridX = gridx;
+        this.gridY = gridy;
+        name = "Wall";
+        canMoveTo = false;
+        canShoot = false;
+        image = new Rectangle(WIDTH, HEIGHT);
+        ((Rectangle) image).setFill(new ImagePattern(MediaUtil.createImage(String.format(FILE_PATH, 1))));
+    }
 }

--- a/src/main/java/ca/ciccc/silverBullet/gridNodes/Water.java
+++ b/src/main/java/ca/ciccc/silverBullet/gridNodes/Water.java
@@ -6,15 +6,14 @@ import javafx.scene.shape.Rectangle;
 
 public class Water extends GridNode {
 
-  public Water(int gridx, int gridy) {
-    this.gridX = gridx;
-    this.gridY = gridy;
+    public Water(int gridx, int gridy) {
+        this.gridX = gridx;
+        this.gridY = gridy;
 
-    this.name = "Water";
-    this.canMoveTo = false;
-    this.canShoot = true;
-    this.image = new Rectangle(WIDTH, HEIGHT);
-    ((Rectangle) image)
-        .setFill(new ImagePattern(MediaUtil.createImage("/images/Wave.gif")));
-  }
+        this.name = "Water";
+        this.canMoveTo = false;
+        this.canShoot = true;
+        this.image = new Rectangle(WIDTH, HEIGHT);
+        ((Rectangle) image).setFill(new ImagePattern(MediaUtil.createImage("/images/Wave.gif")));
+    }
 }

--- a/src/main/java/ca/ciccc/silverBullet/logic/GameLogic.java
+++ b/src/main/java/ca/ciccc/silverBullet/logic/GameLogic.java
@@ -14,109 +14,113 @@ import ca.ciccc.silverBullet.enums.gameplay.Directions;
  */
 public final class GameLogic {
 
-  private GameLogic() {
-  }
+    private GameLogic() {}
 
-  /** Answers a yes/no question about the tile at {@code (x, y)}. */
-  @FunctionalInterface
-  public interface TilePredicate {
-    boolean test(int x, int y);
-  }
-
-  /**
-   * Where a player standing at {@code (startX, startY)} and facing
-   * {@code facing} ends up after a single MOVE action.
-   *
-   * <p>The move is one tile ahead. It is refused (returns {@code null}) when the
-   * destination is off the board, impassable, or already occupied by another
-   * player — mirroring {@code GridBoard.tryMovePlayer}.
-   *
-   * @param maxX inclusive maximum X coordinate on the board
-   * @param maxY inclusive maximum Y coordinate on the board
-   * @param passable whether a tile may be moved onto (walls/water/holes are not)
-   * @param occupied whether a tile already holds a player
-   * @return the destination as {@code {x, y}}, or {@code null} if blocked
-   */
-  public static int[] moveDestination(int startX, int startY, Directions facing,
-      int maxX, int maxY, TilePredicate passable, TilePredicate occupied) {
-    int targetX = startX + facing.dx();
-    int targetY = startY + facing.dy();
-
-    if (targetX < 0 || targetY < 0 || targetX > maxX || targetY > maxY) {
-      return null;
-    }
-    if (!occupied.test(targetX, targetY) && passable.test(targetX, targetY)) {
-      return new int[] {targetX, targetY};
-    }
-    return null;
-  }
-
-  /**
-   * The tile a bullet fired from {@code (startX, startY)} facing {@code facing}
-   * comes to rest on.
-   *
-   * <p>The shot walks tile-by-tile away from the shooter, passing over passable
-   * tiles until it meets an impassable tile or the board edge, and stops on the
-   * last passable tile it reached — mirroring {@code GridBoard.tryShoot}. If the
-   * very next tile is impassable, there is no travel and {@code null} is
-   * returned.
-   *
-   * @param maxX inclusive maximum X coordinate on the board
-   * @param maxY inclusive maximum Y coordinate on the board
-   * @param passable whether the bullet may travel over a tile
-   * @return the endpoint as {@code {x, y}}, or {@code null} if the shot travels nowhere
-   */
-  public static int[] shotEndpoint(int startX, int startY, Directions facing,
-      int maxX, int maxY, TilePredicate passable) {
-    int lastX = -1;
-    int lastY = -1;
-    boolean reachedAny = false;
-
-    for (int step = 1; ; step++) {
-      int x = startX + facing.dx() * step;
-      int y = startY + facing.dy() * step;
-
-      if (x < 0 || y < 0 || x > maxX || y > maxY) {
-        break;
-      }
-      if (!passable.test(x, y)) {
-        break;
-      }
-      lastX = x;
-      lastY = y;
-      reachedAny = true;
+    /** Answers a yes/no question about the tile at {@code (x, y)}. */
+    @FunctionalInterface
+    public interface TilePredicate {
+        boolean test(int x, int y);
     }
 
-    return reachedAny ? new int[] {lastX, lastY} : null;
-  }
+    /**
+     * Where a player standing at {@code (startX, startY)} and facing
+     * {@code facing} ends up after a single MOVE action.
+     *
+     * <p>The move is one tile ahead. It is refused (returns {@code null}) when the
+     * destination is off the board, impassable, or already occupied by another
+     * player — mirroring {@code GridBoard.tryMovePlayer}.
+     *
+     * @param maxX inclusive maximum X coordinate on the board
+     * @param maxY inclusive maximum Y coordinate on the board
+     * @param passable whether a tile may be moved onto (walls/water/holes are not)
+     * @param occupied whether a tile already holds a player
+     * @return the destination as {@code {x, y}}, or {@code null} if blocked
+     */
+    public static int[] moveDestination(
+            int startX,
+            int startY,
+            Directions facing,
+            int maxX,
+            int maxY,
+            TilePredicate passable,
+            TilePredicate occupied) {
+        int targetX = startX + facing.dx();
+        int targetY = startY + facing.dy();
 
-  /**
-   * Resolve a set of simultaneous player moves. Each entry of {@code targets}
-   * is a player's destination tile as {@code {x, y}}, or {@code null} if that
-   * player is not moving this step. A player may complete its move only if no
-   * other player targets the same destination; when two or more contend for a
-   * tile they collide and none of them moves. The decision is taken from this
-   * snapshot, so it does not depend on the order moves are applied.
-   *
-   * @param targets each player's destination this step (null = not moving)
-   * @return a parallel array: {@code true} where that player should move
-   */
-  public static boolean[] resolveSimultaneousMoves(int[][] targets) {
-    boolean[] canMove = new boolean[targets.length];
-    for (int i = 0; i < targets.length; i++) {
-      if (targets[i] == null) {
-        continue;
-      }
-      boolean contended = false;
-      for (int j = 0; j < targets.length; j++) {
-        if (j != i && targets[j] != null
-            && targets[j][0] == targets[i][0] && targets[j][1] == targets[i][1]) {
-          contended = true;
-          break;
+        if (targetX < 0 || targetY < 0 || targetX > maxX || targetY > maxY) {
+            return null;
         }
-      }
-      canMove[i] = !contended;
+        if (!occupied.test(targetX, targetY) && passable.test(targetX, targetY)) {
+            return new int[] {targetX, targetY};
+        }
+        return null;
     }
-    return canMove;
-  }
+
+    /**
+     * The tile a bullet fired from {@code (startX, startY)} facing {@code facing}
+     * comes to rest on.
+     *
+     * <p>The shot walks tile-by-tile away from the shooter, passing over passable
+     * tiles until it meets an impassable tile or the board edge, and stops on the
+     * last passable tile it reached — mirroring {@code GridBoard.tryShoot}. If the
+     * very next tile is impassable, there is no travel and {@code null} is
+     * returned.
+     *
+     * @param maxX inclusive maximum X coordinate on the board
+     * @param maxY inclusive maximum Y coordinate on the board
+     * @param passable whether the bullet may travel over a tile
+     * @return the endpoint as {@code {x, y}}, or {@code null} if the shot travels nowhere
+     */
+    public static int[] shotEndpoint(
+            int startX, int startY, Directions facing, int maxX, int maxY, TilePredicate passable) {
+        int lastX = -1;
+        int lastY = -1;
+        boolean reachedAny = false;
+
+        for (int step = 1; ; step++) {
+            int x = startX + facing.dx() * step;
+            int y = startY + facing.dy() * step;
+
+            if (x < 0 || y < 0 || x > maxX || y > maxY) {
+                break;
+            }
+            if (!passable.test(x, y)) {
+                break;
+            }
+            lastX = x;
+            lastY = y;
+            reachedAny = true;
+        }
+
+        return reachedAny ? new int[] {lastX, lastY} : null;
+    }
+
+    /**
+     * Resolve a set of simultaneous player moves. Each entry of {@code targets}
+     * is a player's destination tile as {@code {x, y}}, or {@code null} if that
+     * player is not moving this step. A player may complete its move only if no
+     * other player targets the same destination; when two or more contend for a
+     * tile they collide and none of them moves. The decision is taken from this
+     * snapshot, so it does not depend on the order moves are applied.
+     *
+     * @param targets each player's destination this step (null = not moving)
+     * @return a parallel array: {@code true} where that player should move
+     */
+    public static boolean[] resolveSimultaneousMoves(int[][] targets) {
+        boolean[] canMove = new boolean[targets.length];
+        for (int i = 0; i < targets.length; i++) {
+            if (targets[i] == null) {
+                continue;
+            }
+            boolean contended = false;
+            for (int j = 0; j < targets.length; j++) {
+                if (j != i && targets[j] != null && targets[j][0] == targets[i][0] && targets[j][1] == targets[i][1]) {
+                    contended = true;
+                    break;
+                }
+            }
+            canMove[i] = !contended;
+        }
+        return canMove;
+    }
 }

--- a/src/main/java/ca/ciccc/silverBullet/playerElements/ActionCounter.java
+++ b/src/main/java/ca/ciccc/silverBullet/playerElements/ActionCounter.java
@@ -20,250 +20,250 @@ import javafx.scene.text.Text;
 
 public class ActionCounter extends Pane {
 
-  private Image player1 = MediaUtil.createImage("/images/wf.png");
-  private Image player2 = MediaUtil.createImage("/images/wr.png");
-  private Image player3 = MediaUtil.createImage("/images/ww.png");
-  private Image player4 = MediaUtil.createImage("/images/wwi.png");
+    private Image player1 = MediaUtil.createImage("/images/wf.png");
+    private Image player2 = MediaUtil.createImage("/images/wr.png");
+    private Image player3 = MediaUtil.createImage("/images/ww.png");
+    private Image player4 = MediaUtil.createImage("/images/wwi.png");
 
-  private Circle[] actionNodes;
-  private Text actionsText;
-  private Circle[] manaNodes;
-  private Text manaText;
-  private int nodesEnabled = 0;
-  private Circle playerImage;
-  private Text playerText;
-  private int manaEnabled;
+    private Circle[] actionNodes;
+    private Text actionsText;
+    private Circle[] manaNodes;
+    private Text manaText;
+    private int nodesEnabled = 0;
+    private Circle playerImage;
+    private Text playerText;
+    private int manaEnabled;
 
-  ActionCounter(Player parentPlayer) {
-    manaEnabled = 3;
+    ActionCounter(Player parentPlayer) {
+        manaEnabled = 3;
 
-    actionNodes = new Circle[5];
-    generateNodes();
+        actionNodes = new Circle[5];
+        generateNodes();
 
-    manaNodes = new Circle[3];
-    generateMana();
+        manaNodes = new Circle[3];
+        generateMana();
 
-    Font.loadFont("File:/Font/Pixel.ttf", 120);
+        Font.loadFont("File:/Font/Pixel.ttf", 120);
 
-    playerText = new Text("Player " + parentPlayer.getPlayerNumber());
-    playerText.setFill(Color.WHITE);
-    playerText.setFont(
-        Font.font("Pixel", FontWeight.SEMI_BOLD, 12)
-    );
-    //playerText.setStyle("Pixel");
-    playerText.setTranslateX(300);
-    playerText.setTranslateY(25);
-    this.getChildren().add(playerText);
+        playerText = new Text("Player " + parentPlayer.getPlayerNumber());
+        playerText.setFill(Color.WHITE);
+        playerText.setFont(Font.font("Pixel", FontWeight.SEMI_BOLD, 12));
+        // playerText.setStyle("Pixel");
+        playerText.setTranslateX(300);
+        playerText.setTranslateY(25);
+        this.getChildren().add(playerText);
 
-    actionsText = new Text("Actions");
-    actionsText.setFill(Color.WHITE);
-    actionsText.setFont(
-        Font.font("Pixel", FontWeight.NORMAL, 12)
-    );
+        actionsText = new Text("Actions");
+        actionsText.setFill(Color.WHITE);
+        actionsText.setFont(Font.font("Pixel", FontWeight.NORMAL, 12));
 
-    BackgroundPosition custom = new BackgroundPosition(Side.RIGHT, 0D, true, Side.TOP, 0.5D, true);
+        BackgroundPosition custom = new BackgroundPosition(Side.RIGHT, 0D, true, Side.TOP, 0.5D, true);
 
-    switch (parentPlayer.getPlayerNumber()) {
-      case 1:
-        this.setBackground(new Background(
-            new BackgroundImage(player1, BackgroundRepeat.NO_REPEAT, BackgroundRepeat.NO_REPEAT,
-                custom, BackgroundSize.DEFAULT)));
-        break;
-      case 2:
-        this.setBackground(new Background(
-            new BackgroundImage(player2, BackgroundRepeat.NO_REPEAT, BackgroundRepeat.NO_REPEAT,
-                custom, BackgroundSize.DEFAULT)));
-        break;
-      case 3:
-        this.setBackground(new Background(
-            new BackgroundImage(player3, BackgroundRepeat.NO_REPEAT, BackgroundRepeat.NO_REPEAT,
-                custom, BackgroundSize.DEFAULT)));
-        break;
-      case 4:
-        this.setBackground(new Background(
-            new BackgroundImage(player4, BackgroundRepeat.NO_REPEAT, BackgroundRepeat.NO_REPEAT,
-                custom, BackgroundSize.DEFAULT)));
-        break;
+        switch (parentPlayer.getPlayerNumber()) {
+            case 1:
+                this.setBackground(new Background(new BackgroundImage(
+                        player1,
+                        BackgroundRepeat.NO_REPEAT,
+                        BackgroundRepeat.NO_REPEAT,
+                        custom,
+                        BackgroundSize.DEFAULT)));
+                break;
+            case 2:
+                this.setBackground(new Background(new BackgroundImage(
+                        player2,
+                        BackgroundRepeat.NO_REPEAT,
+                        BackgroundRepeat.NO_REPEAT,
+                        custom,
+                        BackgroundSize.DEFAULT)));
+                break;
+            case 3:
+                this.setBackground(new Background(new BackgroundImage(
+                        player3,
+                        BackgroundRepeat.NO_REPEAT,
+                        BackgroundRepeat.NO_REPEAT,
+                        custom,
+                        BackgroundSize.DEFAULT)));
+                break;
+            case 4:
+                this.setBackground(new Background(new BackgroundImage(
+                        player4,
+                        BackgroundRepeat.NO_REPEAT,
+                        BackgroundRepeat.NO_REPEAT,
+                        custom,
+                        BackgroundSize.DEFAULT)));
+                break;
+        }
+
+        manaText = new Text("Mana");
+        manaText.setFont(Font.font("Pixel", FontWeight.NORMAL, 11));
+        manaText.setFill(Color.WHITE);
+        manaText.setTranslateX(80);
+        manaText.setTranslateY(35);
+        this.getChildren().add(manaText);
+
+        this.setPrefSize(380, 100);
+
+        actionsText.setTranslateX(70);
+        actionsText.setTranslateY(65);
+        this.getChildren().add(actionsText);
+
+        Node playerToLookAt = parentPlayer.getPlayerNode();
+
+        playerImage = new Circle(25, ((Circle) playerToLookAt).getFill());
+        playerImage.setTranslateX(320);
+        playerImage.setTranslateY(60);
+        this.getChildren().add(playerImage);
     }
 
-    manaText = new Text("Mana");
-    manaText.setFont(
-        Font.font("Pixel", FontWeight.NORMAL, 11)
-    );
-    manaText.setFill(Color.WHITE);
-    manaText.setTranslateX(80);
-    manaText.setTranslateY(35);
-    this.getChildren().add(manaText);
-
-    this.setPrefSize(380, 100);
-
-    actionsText.setTranslateX(70);
-    actionsText.setTranslateY(65);
-    this.getChildren().add(actionsText);
-
-    Node playerToLookAt = parentPlayer.getPlayerNode();
-
-    playerImage = new Circle(25, ((Circle) playerToLookAt).getFill());
-    playerImage.setTranslateX(320);
-    playerImage.setTranslateY(60);
-    this.getChildren().add(playerImage);
-
-
-  }
-
-  private void generateNodes() {
-    for (int i = 0; i < 5; i++) {
-      actionNodes[i] = new Circle(10, Color.GRAY);
-      actionNodes[i].setTranslateX((i * 25) + 150);
-      actionNodes[i].setTranslateY(60);
-      this.getChildren().add(actionNodes[i]);
+    private void generateNodes() {
+        for (int i = 0; i < 5; i++) {
+            actionNodes[i] = new Circle(10, Color.GRAY);
+            actionNodes[i].setTranslateX((i * 25) + 150);
+            actionNodes[i].setTranslateY(60);
+            this.getChildren().add(actionNodes[i]);
+        }
     }
-  }
 
-  private void generateMana() {
-    for (int i = 0; i < 3; i++) {
-      manaNodes[i] = new Circle(10, Color.BLUE);
-      manaNodes[i].setTranslateX((i * 25) + 150);
-      manaNodes[i].setTranslateY(30);
-      this.getChildren().add(manaNodes[i]);
+    private void generateMana() {
+        for (int i = 0; i < 3; i++) {
+            manaNodes[i] = new Circle(10, Color.BLUE);
+            manaNodes[i].setTranslateX((i * 25) + 150);
+            manaNodes[i].setTranslateY(30);
+            this.getChildren().add(manaNodes[i]);
+        }
     }
-  }
 
-  void addAction() {
-    nodesEnabled++;
-    if (nodesEnabled > 5) {
-      nodesEnabled = 5;
+    void addAction() {
+        nodesEnabled++;
+        if (nodesEnabled > 5) {
+            nodesEnabled = 5;
+        }
+        for (int i = 0; i < 5; i++) {
+            if (i < nodesEnabled) {
+                actionNodes[i].setFill(Color.RED);
+            } else {
+                actionNodes[i].setFill(Color.GRAY);
+            }
+        }
     }
-    for (int i = 0; i < 5; i++) {
-      if (i < nodesEnabled) {
-        actionNodes[i].setFill(Color.RED);
-      } else {
-        actionNodes[i].setFill(Color.GRAY);
-      }
+
+    void removeAction() {
+        nodesEnabled--;
+        if (nodesEnabled < 0) {
+            nodesEnabled = 0;
+        }
+        for (int i = 0; i < 5; i++) {
+            if (i >= 5 - nodesEnabled) {
+                actionNodes[i].setFill(Color.RED);
+            } else {
+                actionNodes[i].setFill(Color.GRAY);
+            }
+        }
     }
-  }
 
-  void removeAction() {
-    nodesEnabled--;
-    if (nodesEnabled < 0) {
-      nodesEnabled = 0;
+    void addShot() {
+        manaEnabled++;
+        if (manaEnabled > 3) {
+            manaEnabled = 3;
+        }
+        for (int i = 0; i < 3; i++) {
+            if (i < manaEnabled) {
+                manaNodes[i].setFill(Color.BLUE);
+            } else {
+                manaNodes[i].setFill(Color.GRAY);
+            }
+        }
     }
-    for (int i = 0; i < 5; i++) {
-      if (i >= 5 - nodesEnabled) {
-        actionNodes[i].setFill(Color.RED);
-      } else {
-        actionNodes[i].setFill(Color.GRAY);
-      }
+
+    void removeShot() {
+        manaEnabled--;
+        if (manaEnabled < 0) {
+            manaEnabled = 0;
+        }
+        for (int i = 0; i < 3; i++) {
+            if (i >= 3 - manaEnabled) {
+                manaNodes[i].setFill(Color.BLUE);
+            } else {
+                manaNodes[i].setFill(Color.GRAY);
+            }
+        }
     }
-  }
 
-  void addShot() {
-    manaEnabled++;
-    if (manaEnabled > 3) {
-      manaEnabled = 3;
+    public void clearActions() {
+        for (int i = 0; i < 5; i++) {
+            actionNodes[i].setFill(Color.GRAY);
+        }
+        nodesEnabled = 0;
     }
-    for (int i = 0; i < 3; i++) {
-      if (i < manaEnabled) {
-        manaNodes[i].setFill(Color.BLUE);
-      } else {
-        manaNodes[i].setFill(Color.GRAY);
-      }
+
+    private void adjustManaNodes(int adjustment) {
+        for (Circle c : manaNodes) {
+            c.setTranslateX(c.getTranslateX() - adjustment);
+        }
     }
-  }
 
-  void removeShot() {
-    manaEnabled--;
-    if (manaEnabled < 0) {
-      manaEnabled = 0;
+    private void adjustActionNodes(int adjustments) {
+        for (Circle c : actionNodes) {
+            c.setTranslateX(c.getTranslateX() - adjustments);
+        }
     }
-    for (int i = 0; i < 3; i++) {
-      if (i >= 3 - manaEnabled) {
-        manaNodes[i].setFill(Color.BLUE);
-      } else {
-        manaNodes[i].setFill(Color.GRAY);
-      }
+
+    private Text getActionsText() {
+        return actionsText;
     }
-  }
 
-  public void clearActions() {
-    for (int i = 0; i < 5; i++) {
-      actionNodes[i].setFill(Color.GRAY);
+    private Text getManaText() {
+        return manaText;
     }
-    nodesEnabled = 0;
-  }
 
-  private void adjustManaNodes(int adjustment) {
-    for (Circle c : manaNodes) {
-      c.setTranslateX(c.getTranslateX() - adjustment);
+    private Circle getPlayerImage() {
+        return playerImage;
     }
-  }
 
-  private void adjustActionNodes(int adjustments) {
-    for (Circle c : actionNodes) {
-      c.setTranslateX(c.getTranslateX() - adjustments);
+    private Text getPlayerText() {
+        return playerText;
     }
-  }
 
-  private Text getActionsText() {
-    return actionsText;
-  }
+    public void adjustActionCounter(int numberOfPlayers, int i) {
+        if (numberOfPlayers > 2) {
+            this.setPrefSize(400 - (44 * numberOfPlayers), 100);
 
-  private Text getManaText() {
-    return manaText;
-  }
+            this.getActionsText().setTranslateX(70 - (12 * numberOfPlayers));
+            this.getManaText().setTranslateX(75 - (12 * numberOfPlayers));
 
-  private Circle getPlayerImage() {
-    return playerImage;
-  }
+            this.adjustActionNodes(12 * numberOfPlayers);
+            this.adjustManaNodes(12 * numberOfPlayers);
 
-  private Text getPlayerText() {
-    return playerText;
-  }
+            this.getPlayerImage().setTranslateX(this.getPlayerImage().getTranslateX() - (20 * numberOfPlayers));
+            this.getPlayerText().setTranslateX(this.getPlayerText().getTranslateX() - (20 * numberOfPlayers));
+            this.setTranslateX(ConstUtil.GameSceneCoordinatesEnum.SIZE_BOARD_X_MAIN.get()
+                    - (numberOfPlayers == 4 ? 48 : 0)
+                    + (this.getPrefWidth() * i));
 
-  public void adjustActionCounter(int numberOfPlayers, int i) {
-    if (numberOfPlayers > 2) {
-      this.setPrefSize(400 - (44 * numberOfPlayers), 100);
+            this.getChildren().remove(playerImage);
+            this.getChildren().remove(playerText);
 
-      this.getActionsText().setTranslateX(70 - (12 * numberOfPlayers));
-      this.getManaText().setTranslateX(75 - (12 * numberOfPlayers));
-
-      this.adjustActionNodes(12 * numberOfPlayers);
-      this.adjustManaNodes(12 * numberOfPlayers);
-
-      this.getPlayerImage()
-          .setTranslateX(this.getPlayerImage().getTranslateX() - (20 * numberOfPlayers));
-      this.getPlayerText()
-          .setTranslateX(this.getPlayerText().getTranslateX() - (20 * numberOfPlayers));
-      this.setTranslateX(
-          ConstUtil.GameSceneCoordinatesEnum.SIZE_BOARD_X_MAIN.get() - (numberOfPlayers == 4 ? 48
-              : 0) + (this.getPrefWidth() * i));
-
-      this.getChildren().remove(playerImage);
-      this.getChildren().remove(playerText);
-
-    } else {
-      this.setTranslateX(
-          ConstUtil.GameSceneCoordinatesEnum.SIZE_BOARD_X_MAIN.get() + 20 + (this.getPrefWidth()
-              * i));
+        } else {
+            this.setTranslateX(
+                    ConstUtil.GameSceneCoordinatesEnum.SIZE_BOARD_X_MAIN.get() + 20 + (this.getPrefWidth() * i));
+        }
     }
-  }
 
-  public void darkenSelf() {
-    ColorAdjust darken = new ColorAdjust();
-    darken.setBrightness(-.4);
-    this.setEffect(darken);
-  }
+    public void darkenSelf() {
+        ColorAdjust darken = new ColorAdjust();
+        darken.setBrightness(-.4);
+        this.setEffect(darken);
+    }
 
-  public void blackout() {
-    ColorAdjust darken = new ColorAdjust();
-    darken.setBrightness(-.85);
-    this.setEffect(darken);
-  }
+    public void blackout() {
+        ColorAdjust darken = new ColorAdjust();
+        darken.setBrightness(-.85);
+        this.setEffect(darken);
+    }
 
-  public void lightenSelf() {
-    ColorAdjust lighten = new ColorAdjust();
-    lighten.setBrightness(0);
-    this.setEffect(lighten);
-  }
-
+    public void lightenSelf() {
+        ColorAdjust lighten = new ColorAdjust();
+        lighten.setBrightness(0);
+        this.setEffect(lighten);
+    }
 }

--- a/src/main/java/ca/ciccc/silverBullet/playerElements/Bullet.java
+++ b/src/main/java/ca/ciccc/silverBullet/playerElements/Bullet.java
@@ -1,13 +1,11 @@
 package ca.ciccc.silverBullet.playerElements;
 
-import ca.ciccc.silverBullet.utils.ConstUtil;
-import ca.ciccc.silverBullet.utils.MediaUtil;
 import ca.ciccc.silverBullet.enums.gameplay.Directions;
 import ca.ciccc.silverBullet.gameBoard.GridBoard;
 import ca.ciccc.silverBullet.gameBoard.Move;
 import ca.ciccc.silverBullet.gridNodes.GridNode;
-import ca.ciccc.silverBullet.utils.ConstUtil.BulletCoordinatesEnum;
-import javafx.animation.AnimationTimer;
+import ca.ciccc.silverBullet.utils.ConstUtil;
+import ca.ciccc.silverBullet.utils.MediaUtil;
 import javafx.animation.Interpolator;
 import javafx.animation.TranslateTransition;
 import javafx.scene.paint.ImagePattern;
@@ -16,72 +14,64 @@ import javafx.util.Duration;
 
 public class Bullet extends Rectangle {
 
+    Player playerShooting;
+    private final GridBoard board;
 
-  Player playerShooting;
-  private final GridBoard board;
+    public Bullet(Move startPosition, Move endPosition, Player player, GridBoard board) {
+        super(25, 25, 50, 50);
+        playerShooting = player;
+        this.board = board;
 
-  public Bullet(Move startPosition, Move endPosition, Player player, GridBoard board) {
-      super(25, 25, 50, 50);
-      playerShooting = player;
-      this.board = board;
-
-      GridNode startNode = board.getNodeFromGrid(startPosition.getMoveX(), startPosition.getMoveY());
-      GridNode endNode = board.getNodeFromGrid(endPosition.getMoveX(), endPosition.getMoveY());
-      setTranslateX(startNode.getScreenX() - ConstUtil.GridBoardSizeEnum.BOARD_POSITION_X.get() + 10);
-      setTranslateY(startNode.getScreenY() - ConstUtil.GridBoardSizeEnum.BOARD_POSITION_Y.get());
-      shootMovement(startNode, endNode, player);
-  }
-
-  public void shootMovement(GridNode startPos, GridNode endPos, Player player) {
-    TranslateTransition transition = new TranslateTransition();
-
-
-    switch (player.getPlayerNumber()) {
-      case 1:
-        this.setFill(new ImagePattern(
-            MediaUtil.createImage("/images/Character/Fire/FireAttack.png")));
-        break;
-      case 2:
-        this.setFill(new ImagePattern(
-            MediaUtil.createImage("/images/Character/Rock/RockAttack.png")));
-        break;
-      default:
-        this.setFill(new ImagePattern(
-            MediaUtil.createImage("/images/Character/Fire/FireAttack.png")));
-        break;
-      case 3:
-        this.setFill(new ImagePattern(
-            MediaUtil.createImage("/images/Character/Water/WaterAttack.png")));
-        break;
-      case 4:
-        this.setFill(new ImagePattern(
-            MediaUtil.createImage("/images/Character/Wind/WindAttack.png")));
-        break;
+        GridNode startNode = board.getNodeFromGrid(startPosition.getMoveX(), startPosition.getMoveY());
+        GridNode endNode = board.getNodeFromGrid(endPosition.getMoveX(), endPosition.getMoveY());
+        setTranslateX(startNode.getScreenX() - ConstUtil.GridBoardSizeEnum.BOARD_POSITION_X.get() + 10);
+        setTranslateY(startNode.getScreenY() - ConstUtil.GridBoardSizeEnum.BOARD_POSITION_Y.get());
+        shootMovement(startNode, endNode, player);
     }
 
-    if (player.getFacingDirection().equals(Directions.SOUTH) || player.getFacingDirection()
-        .equals(Directions.NORTH)) {
+    public void shootMovement(GridNode startPos, GridNode endPos, Player player) {
+        TranslateTransition transition = new TranslateTransition();
 
-      transition.setFromX(startPos.getScreenX() - ConstUtil.GridBoardSizeEnum.BOARD_POSITION_X.get() + 7);
-      transition.setToX(endPos.getScreenX() - ConstUtil.GridBoardSizeEnum.BOARD_POSITION_X.get() + 7);
+        switch (player.getPlayerNumber()) {
+            case 1:
+                this.setFill(new ImagePattern(MediaUtil.createImage("/images/Character/Fire/FireAttack.png")));
+                break;
+            case 2:
+                this.setFill(new ImagePattern(MediaUtil.createImage("/images/Character/Rock/RockAttack.png")));
+                break;
+            default:
+                this.setFill(new ImagePattern(MediaUtil.createImage("/images/Character/Fire/FireAttack.png")));
+                break;
+            case 3:
+                this.setFill(new ImagePattern(MediaUtil.createImage("/images/Character/Water/WaterAttack.png")));
+                break;
+            case 4:
+                this.setFill(new ImagePattern(MediaUtil.createImage("/images/Character/Wind/WindAttack.png")));
+                break;
+        }
 
-    } else {
-      transition.setFromX(startPos.getScreenX() - ConstUtil.GridBoardSizeEnum.BOARD_POSITION_X.get() + 7);
-      transition.setToX(endPos.getScreenX() - ConstUtil.GridBoardSizeEnum.BOARD_POSITION_X.get() + 7);
+        if (player.getFacingDirection().equals(Directions.SOUTH)
+                || player.getFacingDirection().equals(Directions.NORTH)) {
+
+            transition.setFromX(startPos.getScreenX() - ConstUtil.GridBoardSizeEnum.BOARD_POSITION_X.get() + 7);
+            transition.setToX(endPos.getScreenX() - ConstUtil.GridBoardSizeEnum.BOARD_POSITION_X.get() + 7);
+
+        } else {
+            transition.setFromX(startPos.getScreenX() - ConstUtil.GridBoardSizeEnum.BOARD_POSITION_X.get() + 7);
+            transition.setToX(endPos.getScreenX() - ConstUtil.GridBoardSizeEnum.BOARD_POSITION_X.get() + 7);
+        }
+
+        transition.setFromY(startPos.getScreenY() - ConstUtil.GridBoardSizeEnum.BOARD_POSITION_Y.get());
+        transition.setInterpolator(Interpolator.EASE_IN);
+        transition.setOnFinished(e -> onBulletStop());
+
+        transition.setDuration(Duration.seconds(.5));
+        transition.setToY(endPos.getScreenY() - ConstUtil.GridBoardSizeEnum.BOARD_POSITION_Y.get());
+        transition.setNode(this);
+        transition.play();
     }
 
-    transition.setFromY(startPos.getScreenY() - ConstUtil.GridBoardSizeEnum.BOARD_POSITION_Y.get());
-    transition.setInterpolator(Interpolator.EASE_IN);
-    transition.setOnFinished(e -> onBulletStop());
-
-    transition.setDuration(Duration.seconds(.5));
-    transition.setToY(endPos.getScreenY()- ConstUtil.GridBoardSizeEnum.BOARD_POSITION_Y.get());
-    transition.setNode(this);
-    transition.play();
-  }
-
-
-  public void onBulletStop() {
-    board.gridBoard.getChildren().remove(this);
-  }
+    public void onBulletStop() {
+        board.gridBoard.getChildren().remove(this);
+    }
 }

--- a/src/main/java/ca/ciccc/silverBullet/playerElements/CollisionBullet.java
+++ b/src/main/java/ca/ciccc/silverBullet/playerElements/CollisionBullet.java
@@ -13,85 +13,82 @@ import javafx.util.Duration;
 
 public class CollisionBullet extends Rectangle {
 
-  private AnimationTimer timer;
-  private Player playerShooting;
-  private final GridBoard board;
+    private AnimationTimer timer;
+    private Player playerShooting;
+    private final GridBoard board;
 
-  private Bullet visualBullet;
+    private Bullet visualBullet;
 
-  public CollisionBullet(Move startPosition, Move endPosition, Player player, Bullet otherBulletRef,
-      GridBoard board) {
-      super(5, 5);
+    public CollisionBullet(
+            Move startPosition, Move endPosition, Player player, Bullet otherBulletRef, GridBoard board) {
+        super(5, 5);
 
-      visualBullet = otherBulletRef;
+        visualBullet = otherBulletRef;
 
-      playerShooting = player;
-      this.board = board;
+        playerShooting = player;
+        this.board = board;
 
-      timer = new AnimationTimer() {
-        @Override
-        public void handle(long l) {
-          checkOverlap();
-        }
-      };
+        timer = new AnimationTimer() {
+            @Override
+            public void handle(long l) {
+                checkOverlap();
+            }
+        };
 
-      timer.start();
+        timer.start();
 
-      GridNode startNode = board.getNodeFromGrid(startPosition.getMoveX(), startPosition.getMoveY());
-      GridNode endNode = board.getNodeFromGrid(endPosition.getMoveX(), endPosition.getMoveY());
-      setTranslateX(startNode.getScreenX() + 5);
-      setTranslateY(startNode.getScreenY());
-      shootMovement(startNode, endNode, player);
-  }
-
-  private void shootMovement(GridNode startPos, GridNode endPos, Player player) {
-    TranslateTransition transition = new TranslateTransition();
-
-
-    this.setFill(Color.TRANSPARENT);
-    if (player.getFacingDirection().equals(Directions.SOUTH) || player.getFacingDirection()
-        .equals(Directions.NORTH)) {
-
-      transition.setFromX(startPos.getScreenX() + 5);
-      transition.setToX(endPos.getScreenX() + 5);
-
-    } else {
-      transition.setFromX(startPos.getScreenX() + 5);
-      transition.setToX(endPos.getScreenX() + 5);
+        GridNode startNode = board.getNodeFromGrid(startPosition.getMoveX(), startPosition.getMoveY());
+        GridNode endNode = board.getNodeFromGrid(endPosition.getMoveX(), endPosition.getMoveY());
+        setTranslateX(startNode.getScreenX() + 5);
+        setTranslateY(startNode.getScreenY());
+        shootMovement(startNode, endNode, player);
     }
 
-    transition.setFromY(startPos.getScreenY());
-    transition.setInterpolator(Interpolator.EASE_IN);
-    transition.setOnFinished(e -> onBulletStop());
+    private void shootMovement(GridNode startPos, GridNode endPos, Player player) {
+        TranslateTransition transition = new TranslateTransition();
 
-    transition.setDuration(Duration.seconds(.5));
-    transition.setToY(endPos.getScreenY());
-    transition.setNode(this);
-    transition.play();
-  }
+        this.setFill(Color.TRANSPARENT);
+        if (player.getFacingDirection().equals(Directions.SOUTH)
+                || player.getFacingDirection().equals(Directions.NORTH)) {
 
-  public void checkOverlap(){
-      Player playerToRemove = null;
-    for(int i = 0; i < board.players.size(); i++)
-      if(!board.players.get(i).equals(playerShooting) &&
-              getBoundsInParent().intersects(board.players.get(i).getPlayerNode().getBoundsInParent())){
+            transition.setFromX(startPos.getScreenX() + 5);
+            transition.setToX(endPos.getScreenX() + 5);
 
-          playerToRemove = board.players.get(i);
+        } else {
+            transition.setFromX(startPos.getScreenX() + 5);
+            transition.setToX(endPos.getScreenX() + 5);
+        }
 
+        transition.setFromY(startPos.getScreenY());
+        transition.setInterpolator(Interpolator.EASE_IN);
+        transition.setOnFinished(e -> onBulletStop());
 
-      }
-      if(playerToRemove != null){
+        transition.setDuration(Duration.seconds(.5));
+        transition.setToY(endPos.getScreenY());
+        transition.setNode(this);
+        transition.play();
+    }
 
-          timer.stop();
-          playerToRemove.Die();
-          onBulletStop();
-      }
+    public void checkOverlap() {
+        Player playerToRemove = null;
+        for (int i = 0; i < board.players.size(); i++)
+            if (!board.players.get(i).equals(playerShooting)
+                    && getBoundsInParent()
+                            .intersects(board.players.get(i).getPlayerNode().getBoundsInParent())) {
 
-  }
+                playerToRemove = board.players.get(i);
+            }
+        if (playerToRemove != null) {
 
-  private void onBulletStop() {
-      timer.stop();
-    board.gridBoard.getChildren().remove(this);
-    visualBullet.onBulletStop();
-  }
+            timer.stop();
+            playerToRemove.Die();
+            onBulletStop();
+        }
+    }
+
+    private void onBulletStop() {
+        timer.stop();
+        board.gridBoard.getChildren().remove(this);
+        visualBullet.onBulletStop();
+    }
 }

--- a/src/main/java/ca/ciccc/silverBullet/playerElements/Player.java
+++ b/src/main/java/ca/ciccc/silverBullet/playerElements/Player.java
@@ -14,270 +14,262 @@ import javafx.scene.shape.Circle;
 
 public class Player {
 
+    private int numberOfShots;
 
-  private int numberOfShots;
+    private final GridBoard board;
+    private int playerNumber;
+    private Directions facingDirection;
+    private int gridPositionX;
+    private int gridPositionY;
+    private Move targetMove;
+    private Node playerNode;
+    private PlayerAction[] playerActions = {
+        PlayerAction.NONE, PlayerAction.NONE, PlayerAction.NONE, PlayerAction.NONE, PlayerAction.NONE
+    };
+    private int currentAction = 0;
+    private ActionCounter playerActionCounter;
+    private boolean actionsFull;
 
-  private final GridBoard board;
-  private int playerNumber;
-  private Directions facingDirection;
-  private int gridPositionX;
-  private int gridPositionY;
-  private Move targetMove;
-  private Node playerNode;
-  private PlayerAction[] playerActions = {PlayerAction.NONE, PlayerAction.NONE, PlayerAction.NONE,
-      PlayerAction.NONE, PlayerAction.NONE};
-  private int currentAction = 0;
-  private ActionCounter playerActionCounter;
-  private boolean actionsFull;
+    private boolean isDead;
 
-  private boolean isDead;
-
-  public void setActionsFull(boolean actionsFull) {
-    this.actionsFull = actionsFull;
-  }
-
-  public boolean isActionsFull() {
-    return actionsFull;
-  }
-
-  public boolean isDead() {
-    return isDead;
-  }
-
-  public Player(int numberOfShots, int playerNumber, int gridX, int gridY,
-      Directions facingDirection, GridBoard board) {
-
-    this.numberOfShots = numberOfShots;
-    this.playerNumber = playerNumber;
-    this.facingDirection = facingDirection;
-    this.board = board;
-    gridPositionX = gridX;
-    gridPositionY = gridY;
-    playerNode = new Circle(30, Color.GREEN);
-    Image image = MediaUtil.createImage("/images/Character/Fire/Fire.png");
-    switch (playerNumber) {
-
-      case 1:
-        image = MediaUtil.createImage("/images/Character/Fire/Fire.png");
-        break;
-      case 2:
-        image = MediaUtil.createImage("/images/Character/Rock/Rock.png");
-        break;
-      case 3:
-        image = MediaUtil.createImage("/images/Character/Water/Water.png");
-        break;
-      case 4:
-        image = MediaUtil.createImage("/images/Character/Wind/Wind.png");
-        break;
-
+    public void setActionsFull(boolean actionsFull) {
+        this.actionsFull = actionsFull;
     }
-    ((Circle) playerNode).setFill(new ImagePattern(image));
-    playerActionCounter = new ActionCounter(this);
 
-  }
-
-  private void rotatePlayer(Orientation move) {
-    facingDirection = facingDirection.rotate(move);
-    this.setimage();
-  }
-
-  void Die() {
-    isDead = true;
-    board.removePlayer(this);
-  }
-
-  public void addAction(PlayerAction actionToAdd) {
-    if (!isActionsFull()) {
-      playerActions[currentAction] = actionToAdd;
-      currentAction++;
-      if (currentAction > 4) {
-
-        currentAction = 0;
-        actionsFull = true;
-
-      }
-
-      playerActionCounter.addAction();
+    public boolean isActionsFull() {
+        return actionsFull;
     }
-  }
 
-  public boolean takeAction(int actionNumber) {
-    if (playerActions[actionNumber] == null) {
-      return false;
+    public boolean isDead() {
+        return isDead;
     }
-    switch (playerActions[actionNumber]) {
-      case MOVE:
-        this.targetMove = board.tryMovePlayer(this);
 
-        break;
-      case TURN_LEFT:
-        this.rotatePlayer(Orientation.LEFT);
-        break;
-      case TURN_RIGHT:
-        this.rotatePlayer(Orientation.RIGHT);
-        break;
-      case SHOOT:
-        board.shootBullet(this);
-        removeShot();
-        break;
-      case WAIT:
-        break;
-    }
-    playerActionCounter.removeAction();
-    return true;
-  }
+    public Player(
+            int numberOfShots, int playerNumber, int gridX, int gridY, Directions facingDirection, GridBoard board) {
 
-
-  public void passTurn() {
-    if (!isActionsFull()) {
-      for (PlayerAction playerAction : playerActions) {
-        if (playerAction == PlayerAction.NONE) {
-          addAction(PlayerAction.WAIT);
+        this.numberOfShots = numberOfShots;
+        this.playerNumber = playerNumber;
+        this.facingDirection = facingDirection;
+        this.board = board;
+        gridPositionX = gridX;
+        gridPositionY = gridY;
+        playerNode = new Circle(30, Color.GREEN);
+        Image image = MediaUtil.createImage("/images/Character/Fire/Fire.png");
+        switch (playerNumber) {
+            case 1:
+                image = MediaUtil.createImage("/images/Character/Fire/Fire.png");
+                break;
+            case 2:
+                image = MediaUtil.createImage("/images/Character/Rock/Rock.png");
+                break;
+            case 3:
+                image = MediaUtil.createImage("/images/Character/Water/Water.png");
+                break;
+            case 4:
+                image = MediaUtil.createImage("/images/Character/Wind/Wind.png");
+                break;
         }
-      }
-    }
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (!(obj instanceof Player)) {
-      return false;
-    }
-    Player otherPlayer = (Player) obj;
-    return playerNumber == otherPlayer.getPlayerNumber();
-  }
-
-  public void resetActions() {
-    for (int i = 0; i < 5; i++) {
-      playerActions[i] = PlayerAction.NONE;
-    }
-    actionsFull = false;
-  }
-
-  public void addShot() {
-    numberOfShots++;
-
-    if (numberOfShots > 3) {
-      numberOfShots = 3;
+        ((Circle) playerNode).setFill(new ImagePattern(image));
+        playerActionCounter = new ActionCounter(this);
     }
 
-    playerActionCounter.addShot();
-  }
-
-  private void removeShot() {
-    numberOfShots--;
-    if (numberOfShots < 0) {
-      numberOfShots = 0;
-    }
-    playerActionCounter.removeShot();
-  }
-
-  public ActionCounter getPlayerActionCounter() {
-    return playerActionCounter;
-  }
-
-  public boolean isHasShot() {
-    return numberOfShots > 0;
-  }
-
-  public int getPlayerNumber() {
-    return playerNumber;
-  }
-
-  public void setPlayerNumber(int playerNumber) {
-    this.playerNumber = playerNumber;
-  }
-
-  public Directions getFacingDirection() {
-    return facingDirection;
-  }
-
-  public void setFacingDirection(Directions facingDirection) {
-    this.facingDirection = facingDirection;
-  }
-
-  public int getGridPositionX() {
-    return gridPositionX;
-  }
-
-  public void setGridPositionX(int gridPositionX) {
-    this.gridPositionX = gridPositionX;
-  }
-
-  public int getGridPositionY() {
-    return gridPositionY;
-  }
-
-  public void setGridPositionY(int gridPositionY) {
-    this.gridPositionY = gridPositionY;
-  }
-
-  public Move getTargetMove() {
-    return targetMove;
-  }
-
-  public void setTargetMove(Move targetMove) {
-    this.targetMove = targetMove;
-  }
-
-  public Node getPlayerNode() {
-    return playerNode;
-  }
-
-  public void setPlayerNode(Node playerNode) {
-    this.playerNode = playerNode;
-  }
-
-  public PlayerAction[] getPlayerActions() {
-    return playerActions;
-  }
-
-  public void setPlayerActions(PlayerAction[] playerActions) {
-    this.playerActions = playerActions;
-  }
-
-  public int getCurrentAction() {
-    return currentAction;
-  }
-
-  public int getNumberOfShots() {
-    return numberOfShots;
-  }
-
-  public void setCurrentAction(int currentAction) {
-    this.currentAction = currentAction;
-  }
-
-
-  private void setimage() {
-    int playerNum = this.playerNumber;
-    String playerelement = null;
-    String dirction = null;
-
-    if (this.getFacingDirection() == Directions.SOUTH) {
-      dirction = "";
-    } else if (this.getFacingDirection() == Directions.NORTH) {
-      dirction = "Up";
-    } else if (this.getFacingDirection() == Directions.WEST) {
-      dirction = "L";
-    } else if (this.getFacingDirection() == Directions.EAST) {
-      dirction = "R";
+    private void rotatePlayer(Orientation move) {
+        facingDirection = facingDirection.rotate(move);
+        this.setimage();
     }
 
-    if (playerNum == 1) {
-      playerelement = "Fire";
-    } else if (playerNum == 2) {
-      playerelement = "Rock";
-    } else if (playerNum == 3) {
-      playerelement = "Water";
-    } else if (playerNum == 4) {
-      playerelement = "Wind";
+    void Die() {
+        isDead = true;
+        board.removePlayer(this);
     }
 
-    String path =
-        String.format("/images/Character/%s/%s%s.png", playerelement, playerelement, dirction);
-    Image img = MediaUtil.createImage(path);
-    ((Circle) this.playerNode).setFill(new ImagePattern(img));
-  }
+    public void addAction(PlayerAction actionToAdd) {
+        if (!isActionsFull()) {
+            playerActions[currentAction] = actionToAdd;
+            currentAction++;
+            if (currentAction > 4) {
 
+                currentAction = 0;
+                actionsFull = true;
+            }
+
+            playerActionCounter.addAction();
+        }
+    }
+
+    public boolean takeAction(int actionNumber) {
+        if (playerActions[actionNumber] == null) {
+            return false;
+        }
+        switch (playerActions[actionNumber]) {
+            case MOVE:
+                this.targetMove = board.tryMovePlayer(this);
+
+                break;
+            case TURN_LEFT:
+                this.rotatePlayer(Orientation.LEFT);
+                break;
+            case TURN_RIGHT:
+                this.rotatePlayer(Orientation.RIGHT);
+                break;
+            case SHOOT:
+                board.shootBullet(this);
+                removeShot();
+                break;
+            case WAIT:
+                break;
+        }
+        playerActionCounter.removeAction();
+        return true;
+    }
+
+    public void passTurn() {
+        if (!isActionsFull()) {
+            for (PlayerAction playerAction : playerActions) {
+                if (playerAction == PlayerAction.NONE) {
+                    addAction(PlayerAction.WAIT);
+                }
+            }
+        }
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof Player)) {
+            return false;
+        }
+        Player otherPlayer = (Player) obj;
+        return playerNumber == otherPlayer.getPlayerNumber();
+    }
+
+    public void resetActions() {
+        for (int i = 0; i < 5; i++) {
+            playerActions[i] = PlayerAction.NONE;
+        }
+        actionsFull = false;
+    }
+
+    public void addShot() {
+        numberOfShots++;
+
+        if (numberOfShots > 3) {
+            numberOfShots = 3;
+        }
+
+        playerActionCounter.addShot();
+    }
+
+    private void removeShot() {
+        numberOfShots--;
+        if (numberOfShots < 0) {
+            numberOfShots = 0;
+        }
+        playerActionCounter.removeShot();
+    }
+
+    public ActionCounter getPlayerActionCounter() {
+        return playerActionCounter;
+    }
+
+    public boolean isHasShot() {
+        return numberOfShots > 0;
+    }
+
+    public int getPlayerNumber() {
+        return playerNumber;
+    }
+
+    public void setPlayerNumber(int playerNumber) {
+        this.playerNumber = playerNumber;
+    }
+
+    public Directions getFacingDirection() {
+        return facingDirection;
+    }
+
+    public void setFacingDirection(Directions facingDirection) {
+        this.facingDirection = facingDirection;
+    }
+
+    public int getGridPositionX() {
+        return gridPositionX;
+    }
+
+    public void setGridPositionX(int gridPositionX) {
+        this.gridPositionX = gridPositionX;
+    }
+
+    public int getGridPositionY() {
+        return gridPositionY;
+    }
+
+    public void setGridPositionY(int gridPositionY) {
+        this.gridPositionY = gridPositionY;
+    }
+
+    public Move getTargetMove() {
+        return targetMove;
+    }
+
+    public void setTargetMove(Move targetMove) {
+        this.targetMove = targetMove;
+    }
+
+    public Node getPlayerNode() {
+        return playerNode;
+    }
+
+    public void setPlayerNode(Node playerNode) {
+        this.playerNode = playerNode;
+    }
+
+    public PlayerAction[] getPlayerActions() {
+        return playerActions;
+    }
+
+    public void setPlayerActions(PlayerAction[] playerActions) {
+        this.playerActions = playerActions;
+    }
+
+    public int getCurrentAction() {
+        return currentAction;
+    }
+
+    public int getNumberOfShots() {
+        return numberOfShots;
+    }
+
+    public void setCurrentAction(int currentAction) {
+        this.currentAction = currentAction;
+    }
+
+    private void setimage() {
+        int playerNum = this.playerNumber;
+        String playerelement = null;
+        String dirction = null;
+
+        if (this.getFacingDirection() == Directions.SOUTH) {
+            dirction = "";
+        } else if (this.getFacingDirection() == Directions.NORTH) {
+            dirction = "Up";
+        } else if (this.getFacingDirection() == Directions.WEST) {
+            dirction = "L";
+        } else if (this.getFacingDirection() == Directions.EAST) {
+            dirction = "R";
+        }
+
+        if (playerNum == 1) {
+            playerelement = "Fire";
+        } else if (playerNum == 2) {
+            playerelement = "Rock";
+        } else if (playerNum == 3) {
+            playerelement = "Water";
+        } else if (playerNum == 4) {
+            playerelement = "Wind";
+        }
+
+        String path = String.format("/images/Character/%s/%s%s.png", playerelement, playerelement, dirction);
+        Image img = MediaUtil.createImage(path);
+        ((Circle) this.playerNode).setFill(new ImagePattern(img));
+    }
 }

--- a/src/main/java/ca/ciccc/silverBullet/utils/ConstUtil.java
+++ b/src/main/java/ca/ciccc/silverBullet/utils/ConstUtil.java
@@ -4,137 +4,135 @@ import java.util.ResourceBundle;
 
 public class ConstUtil {
 
-  private static ResourceBundle RESOURCE_BUNDLE = null;
+    private static ResourceBundle RESOURCE_BUNDLE = null;
 
-  public static void setResourceBundle(ResourceBundle resourceBundle) {
-    if (RESOURCE_BUNDLE != null) {
-      throw new IllegalStateException("Already set");
-    }
-    RESOURCE_BUNDLE = resourceBundle;
-  }
-
-  private ConstUtil() {
-  }
-
-  public static String getRbString(String key) {
-    return RESOURCE_BUNDLE.getString(key);
-  }
-
-  public interface hasDoubleSize {
-    double get();
-  }
-
-  public interface hasIntSize {
-    int get();
-  }
-
-  public enum DisplaySizeEnum implements hasDoubleSize {
-    EXTERNAL_FRAME_W(900),
-    EXTERNAL_FRAME_H(600),
-    TITLE_W(EXTERNAL_FRAME_W.get()),
-    TITLE_H(80),
-    MENU_ITEM_W(300),
-    MENU_ITEM_H(80),
-    MENU_IMAGE_W(180),
-    MENU_IMAGE_H(450),
-    MODAL_MIN_W(200),
-    MODAL_MIN_H(100);
-
-    double size;
-
-    DisplaySizeEnum(double size) {
-      this.size = size;
+    public static void setResourceBundle(ResourceBundle resourceBundle) {
+        if (RESOURCE_BUNDLE != null) {
+            throw new IllegalStateException("Already set");
+        }
+        RESOURCE_BUNDLE = resourceBundle;
     }
 
-    public double get() {
-      return this.size;
-    }
-  }
+    private ConstUtil() {}
 
-  public enum FontSizeEnum implements hasDoubleSize {
-    TITLE(100),
-    MENU(DisplaySizeEnum.MENU_ITEM_H.get() / 2);
-
-    double size;
-
-    FontSizeEnum(double size) {
-      this.size = size;
+    public static String getRbString(String key) {
+        return RESOURCE_BUNDLE.getString(key);
     }
 
-    public double get() {
-      return this.size;
-    }
-  }
-
-  public enum GridBoardSizeEnum implements hasIntSize {
-    BOARD_POSITION_X(182),
-    BOARD_POSITION_Y(50),
-    TILE_SIZE(60),
-    SPACE_TARGET_NODE_Y(10),
-    SPACE_TARGET_NODE_X(30),
-    TILE_CORRECTION_COORDINATE(1);
-
-    int size;
-
-    GridBoardSizeEnum(int size) {
-      this.size = size;
+    public interface hasDoubleSize {
+        double get();
     }
 
-    public int get(){
-      return this.size;
+    public interface hasIntSize {
+        int get();
     }
-  }
+
+    public enum DisplaySizeEnum implements hasDoubleSize {
+        EXTERNAL_FRAME_W(900),
+        EXTERNAL_FRAME_H(600),
+        TITLE_W(EXTERNAL_FRAME_W.get()),
+        TITLE_H(80),
+        MENU_ITEM_W(300),
+        MENU_ITEM_H(80),
+        MENU_IMAGE_W(180),
+        MENU_IMAGE_H(450),
+        MODAL_MIN_W(200),
+        MODAL_MIN_H(100);
+
+        double size;
+
+        DisplaySizeEnum(double size) {
+            this.size = size;
+        }
+
+        public double get() {
+            return this.size;
+        }
+    }
+
+    public enum FontSizeEnum implements hasDoubleSize {
+        TITLE(100),
+        MENU(DisplaySizeEnum.MENU_ITEM_H.get() / 2);
+
+        double size;
+
+        FontSizeEnum(double size) {
+            this.size = size;
+        }
+
+        public double get() {
+            return this.size;
+        }
+    }
+
+    public enum GridBoardSizeEnum implements hasIntSize {
+        BOARD_POSITION_X(182),
+        BOARD_POSITION_Y(50),
+        TILE_SIZE(60),
+        SPACE_TARGET_NODE_Y(10),
+        SPACE_TARGET_NODE_X(30),
+        TILE_CORRECTION_COORDINATE(1);
+
+        int size;
+
+        GridBoardSizeEnum(int size) {
+            this.size = size;
+        }
+
+        public int get() {
+            return this.size;
+        }
+    }
 
     public enum BulletCoordinatesEnum implements hasIntSize {
-      SHOOT_START_POS_X(45),
-      SHOOT_END_POS_X(45),
-      SHOOT_START_POS_Y(50),
-      SHOOT_END_POS_Y(50);
+        SHOOT_START_POS_X(45),
+        SHOOT_END_POS_X(45),
+        SHOOT_START_POS_Y(50),
+        SHOOT_END_POS_Y(50);
 
-      int size;
+        int size;
 
-      BulletCoordinatesEnum(int size) {
-        this.size = size;
-      }
+        BulletCoordinatesEnum(int size) {
+            this.size = size;
+        }
 
-    public int get(){
-      return this.size;
-    }
-  }
-
-  public enum GameSceneCoordinatesEnum implements hasIntSize {
-    SIZE_BOARD_X(305),
-    SIZE_BOARD_Y(630),
-    SIZE_BOARD_X_MAIN(50),
-    SIZE_BOARD_Y_MAIN(590),
-    TIMER_DISPLAY_X(380),
-    TIMER_DISPLAY_Y(10),
-    SIZE_BOARD_TILE(9),
-    POSITION_PLAYER_1_X(1),
-    POSITION_PLAYER_1_Y(1),
-    POSITION_PLAYER_2_X(5),
-    POSITION_PLAYER_2_Y(5),
-    LEVEL_SELECTED(3),
-    PLAYER_NUMBER_1(1),
-    PLAYER_NUMBER_2(2);
-
-    int size;
-
-    GameSceneCoordinatesEnum(int size) {
-      this.size = size;
+        public int get() {
+            return this.size;
+        }
     }
 
-    public int get(){
-      return this.size;
+    public enum GameSceneCoordinatesEnum implements hasIntSize {
+        SIZE_BOARD_X(305),
+        SIZE_BOARD_Y(630),
+        SIZE_BOARD_X_MAIN(50),
+        SIZE_BOARD_Y_MAIN(590),
+        TIMER_DISPLAY_X(380),
+        TIMER_DISPLAY_Y(10),
+        SIZE_BOARD_TILE(9),
+        POSITION_PLAYER_1_X(1),
+        POSITION_PLAYER_1_Y(1),
+        POSITION_PLAYER_2_X(5),
+        POSITION_PLAYER_2_Y(5),
+        LEVEL_SELECTED(3),
+        PLAYER_NUMBER_1(1),
+        PLAYER_NUMBER_2(2);
+
+        int size;
+
+        GameSceneCoordinatesEnum(int size) {
+            this.size = size;
+        }
+
+        public int get() {
+            return this.size;
+        }
     }
-  }
 
-  public static final String APP_NAME = "SILVER BULLET";
-  public static final String TITLE_FONT = "Times New Roman";
-  public static final String MENU_FONT = "Times New Roman";
-  public static final int[] PLAYER_NUMBERS = new int[]{2, 3, 4};
-  public static final int DEFAULT_PLAYER_NUMBER_INDEX = 0;
-  public static final int[] GAME_LEVEL_NUMBERS = new int[]{1, 2, 3};
-  public static final int DEFAULT_GAME_LEVEL_INDEX = 0;
-
+    public static final String APP_NAME = "SILVER BULLET";
+    public static final String TITLE_FONT = "Times New Roman";
+    public static final String MENU_FONT = "Times New Roman";
+    public static final int[] PLAYER_NUMBERS = new int[] {2, 3, 4};
+    public static final int DEFAULT_PLAYER_NUMBER_INDEX = 0;
+    public static final int[] GAME_LEVEL_NUMBERS = new int[] {1, 2, 3};
+    public static final int DEFAULT_GAME_LEVEL_INDEX = 0;
 }

--- a/src/main/java/ca/ciccc/silverBullet/utils/LevelFileReadUtil.java
+++ b/src/main/java/ca/ciccc/silverBullet/utils/LevelFileReadUtil.java
@@ -2,8 +2,6 @@ package ca.ciccc.silverBullet.utils;
 
 import ca.ciccc.silverBullet.SilverBulletApp;
 import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -11,33 +9,33 @@ import java.nio.charset.StandardCharsets;
 
 public class LevelFileReadUtil {
 
-  private static final String FILE_PATH = "levels/level%s.txt";
+    private static final String FILE_PATH = "levels/level%s.txt";
 
-  private LevelFileReadUtil(){}
+    private LevelFileReadUtil() {}
 
-  public static char[][] getLevelMapAry(int levelSelected) {
-    char[][] level = new char[9][9];
-    try (InputStream is = SilverBulletApp.class.getResourceAsStream(String.format(FILE_PATH, levelSelected));
-        BufferedReader br = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
-      // Read the txt of the levels
-      // and get if it is:
-      // W -> Wall
-      // S -> Space
-      // E -> Water
-      // H -> Hole
+    public static char[][] getLevelMapAry(int levelSelected) {
+        char[][] level = new char[9][9];
+        try (InputStream is = SilverBulletApp.class.getResourceAsStream(String.format(FILE_PATH, levelSelected));
+                BufferedReader br = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
+            // Read the txt of the levels
+            // and get if it is:
+            // W -> Wall
+            // S -> Space
+            // E -> Water
+            // H -> Hole
 
-      // Read the next line of the file
-      String line;
-      for (int i = 0; i < 9; i++) {
-        line = br.readLine();
-        for (int j = 0; j < 9; j++) {
-          level[i][j] = line.charAt(j);
+            // Read the next line of the file
+            String line;
+            for (int i = 0; i < 9; i++) {
+                line = br.readLine();
+                for (int j = 0; j < 9; j++) {
+                    level[i][j] = line.charAt(j);
+                }
+            }
+        } catch (IOException ioE) {
+            ioE.printStackTrace();
+            throw new RuntimeException(ioE);
         }
-      }
-    } catch (IOException ioE) {
-      ioE.printStackTrace();
-      throw new RuntimeException(ioE);
+        return level;
     }
-    return level;
-  }
 }

--- a/src/main/java/ca/ciccc/silverBullet/utils/MediaUtil.java
+++ b/src/main/java/ca/ciccc/silverBullet/utils/MediaUtil.java
@@ -6,32 +6,31 @@ import javafx.scene.media.AudioClip;
 
 public class MediaUtil {
 
-  private static final String RESOURCE_ROOT = "/ca/ciccc/silverBullet";
+    private static final String RESOURCE_ROOT = "/ca/ciccc/silverBullet";
 
-  private MediaUtil() {
-  }
+    private MediaUtil() {}
 
-  public static Image createImage(String filePath) {
-    Image result = new Image(resolve(filePath));
-    if (result.getException() != null) {
-      result.getException().printStackTrace();
+    public static Image createImage(String filePath) {
+        Image result = new Image(resolve(filePath));
+        if (result.getException() != null) {
+            result.getException().printStackTrace();
+        }
+        return result;
     }
-    return result;
-  }
 
-  public static AudioClip createClip(String filePath) throws RuntimeException {
-    return new AudioClip(resolve(filePath));
-  }
+    public static AudioClip createClip(String filePath) throws RuntimeException {
+        return new AudioClip(resolve(filePath));
+    }
 
-  /**
-   * Resolve a resource to a loadable URL via the class loader. This yields a
-   * {@code jrt:} URL inside the jlink runtime image and a {@code file:}/
-   * {@code jar:} URL when running from the classpath (dev and tests), so assets
-   * load in every environment. Falls back to the raw path when the resource is
-   * missing, keeping asset loading non-fatal.
-   */
-  private static String resolve(String filePath) {
-    URL url = MediaUtil.class.getResource(RESOURCE_ROOT + filePath);
-    return url != null ? url.toExternalForm() : RESOURCE_ROOT + filePath;
-  }
+    /**
+     * Resolve a resource to a loadable URL via the class loader. This yields a
+     * {@code jrt:} URL inside the jlink runtime image and a {@code file:}/
+     * {@code jar:} URL when running from the classpath (dev and tests), so assets
+     * load in every environment. Falls back to the raw path when the resource is
+     * missing, keeping asset loading non-fatal.
+     */
+    private static String resolve(String filePath) {
+        URL url = MediaUtil.class.getResource(RESOURCE_ROOT + filePath);
+        return url != null ? url.toExternalForm() : RESOURCE_ROOT + filePath;
+    }
 }

--- a/src/main/java/ca/ciccc/silverBullet/utils/ModalUtil.java
+++ b/src/main/java/ca/ciccc/silverBullet/utils/ModalUtil.java
@@ -1,10 +1,6 @@
 package ca.ciccc.silverBullet.utils;
 
-import ca.ciccc.silverBullet.controller.MenuController;
 import ca.ciccc.silverBullet.utils.ConstUtil.DisplaySizeEnum;
-import java.util.function.Supplier;
-import javafx.event.ActionEvent;
-import javafx.event.EventHandler;
 import javafx.geometry.Pos;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
@@ -22,73 +18,71 @@ import javafx.stage.Stage;
  */
 public class ModalUtil {
 
-  private ModalUtil() {
-  }
+    private ModalUtil() {}
 
-  public static void confirm(String title, String message, Runnable action) {
-    Stage modalStage = ModalUtil.createModalStage(title);
-    Pane parentPane = ModalUtil.createModalPane();
+    public static void confirm(String title, String message, Runnable action) {
+        Stage modalStage = ModalUtil.createModalStage(title);
+        Pane parentPane = ModalUtil.createModalPane();
 
-    Label label = new Label();
-    label.setText(message);
+        Label label = new Label();
+        label.setText(message);
 
-    Button executeButton = new Button(ConstUtil.getRbString("modal.ok"));
-    executeButton.setOnAction(e -> {
-      action.run();
-      modalStage.close();
-    });
+        Button executeButton = new Button(ConstUtil.getRbString("modal.ok"));
+        executeButton.setOnAction(e -> {
+            action.run();
+            modalStage.close();
+        });
 
-    Button closeButton = new Button(ConstUtil.getRbString("modal.cancel"));
-    closeButton.setOnAction(e -> modalStage.close());
+        Button closeButton = new Button(ConstUtil.getRbString("modal.cancel"));
+        closeButton.setOnAction(e -> modalStage.close());
 
-    VBox textBox = new VBox(10);
-    textBox.setAlignment(Pos.CENTER);
-    textBox.getChildren().add(label);
-    textBox.setTranslateX(15);
-    textBox.setTranslateY(20);
+        VBox textBox = new VBox(10);
+        textBox.setAlignment(Pos.CENTER);
+        textBox.getChildren().add(label);
+        textBox.setTranslateX(15);
+        textBox.setTranslateY(20);
 
-    HBox btnBox = new HBox(10);
-    btnBox.setAlignment(Pos.CENTER);
-    btnBox.setTranslateX(50);
-    btnBox.setTranslateY(50);
-    btnBox.getChildren().addAll(executeButton, closeButton);
+        HBox btnBox = new HBox(10);
+        btnBox.setAlignment(Pos.CENTER);
+        btnBox.setTranslateX(50);
+        btnBox.setTranslateY(50);
+        btnBox.getChildren().addAll(executeButton, closeButton);
 
-    parentPane.getChildren().addAll(textBox, btnBox);
+        parentPane.getChildren().addAll(textBox, btnBox);
 
-    modalStage.setScene(new Scene(parentPane));
-    /* Its need to be close before do other things out of the window */
-    modalStage.showAndWait();
-  }
+        modalStage.setScene(new Scene(parentPane));
+        /* Its need to be close before do other things out of the window */
+        modalStage.showAndWait();
+    }
 
-  public static void alert(String title, String message) {
-    Stage modalStage = ModalUtil.createModalStage(title);
-    Pane parentPane = ModalUtil.createModalPane();
+    public static void alert(String title, String message) {
+        Stage modalStage = ModalUtil.createModalStage(title);
+        Pane parentPane = ModalUtil.createModalPane();
 
-    Label label = new Label();
-    label.setText(message);
+        Label label = new Label();
+        label.setText(message);
 
-    Button okButton = new Button(ConstUtil.getRbString("modal.ok"));
-    okButton.setOnAction(e -> modalStage.close());
+        Button okButton = new Button(ConstUtil.getRbString("modal.ok"));
+        okButton.setOnAction(e -> modalStage.close());
 
-    VBox textBox = new VBox(10);
-    textBox.setAlignment(Pos.CENTER);
-    textBox.getChildren().add(label);
-    textBox.setTranslateX(15);
-    textBox.setTranslateY(20);
+        VBox textBox = new VBox(10);
+        textBox.setAlignment(Pos.CENTER);
+        textBox.getChildren().add(label);
+        textBox.setTranslateX(15);
+        textBox.setTranslateY(20);
 
-    HBox btnBox = new HBox(10);
-    btnBox.setAlignment(Pos.CENTER);
-    btnBox.setTranslateX(50);
-    btnBox.setTranslateY(50);
-    btnBox.getChildren().addAll(okButton);
+        HBox btnBox = new HBox(10);
+        btnBox.setAlignment(Pos.CENTER);
+        btnBox.setTranslateX(50);
+        btnBox.setTranslateY(50);
+        btnBox.getChildren().addAll(okButton);
 
-    parentPane.getChildren().addAll(textBox, btnBox);
+        parentPane.getChildren().addAll(textBox, btnBox);
 
-    modalStage.setScene(new Scene(parentPane));
-    /* Its need to be close before do other things out of the window */
-    modalStage.showAndWait();
-
-  }
+        modalStage.setScene(new Scene(parentPane));
+        /* Its need to be close before do other things out of the window */
+        modalStage.showAndWait();
+    }
 
     public static void alertWithCallback(String title, String message, Runnable runnable) {
         Stage modalStage = ModalUtil.createModalStage(title);
@@ -120,25 +114,21 @@ public class ModalUtil {
         modalStage.setScene(new Scene(parentPane));
         /* Its need to be close before do other things out of the window */
         modalStage.show();
-
     }
 
+    private static Stage createModalStage(String title) {
+        Stage modalStage = new Stage();
 
-  private static Stage createModalStage(String title) {
-    Stage modalStage = new Stage();
+        /* We don't permit to press other this out of this window if we don't close first */
+        modalStage.initModality(Modality.APPLICATION_MODAL);
+        modalStage.setTitle(title);
 
-    /* We don't permit to press other this out of this window if we don't close first */
-    modalStage.initModality(Modality.APPLICATION_MODAL);
-    modalStage.setTitle(title);
+        return modalStage;
+    }
 
-    return modalStage;
-  }
-
-  private static Pane createModalPane() {
-    Pane parentPane = new Pane();
-    parentPane.setPrefSize(DisplaySizeEnum.MODAL_MIN_W.get(),
-        DisplaySizeEnum.MODAL_MIN_H.get());
-    return parentPane;
-  }
-
+    private static Pane createModalPane() {
+        Pane parentPane = new Pane();
+        parentPane.setPrefSize(DisplaySizeEnum.MODAL_MIN_W.get(), DisplaySizeEnum.MODAL_MIN_H.get());
+        return parentPane;
+    }
 }

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,13 +1,16 @@
 module SilverBulletModule {
-
     requires javafx.graphics;
     requires javafx.controls;
     requires javafx.media;
     requires javafx.fxml;
     requires java.desktop;
 
-    opens ca.ciccc.silverBullet.controller to javafx.fxml;
-    opens ca.ciccc.silverBullet to javafx.graphics, javafx.fxml, java.desktop;
+    opens ca.ciccc.silverBullet.controller to
+            javafx.fxml;
+    opens ca.ciccc.silverBullet to
+            javafx.graphics,
+            javafx.fxml,
+            java.desktop;
 
     exports ca.ciccc.silverBullet;
 }

--- a/src/test/java/ca/ciccc/silverBullet/enums/gameplay/DirectionsTest.java
+++ b/src/test/java/ca/ciccc/silverBullet/enums/gameplay/DirectionsTest.java
@@ -6,72 +6,74 @@ import org.junit.jupiter.api.Test;
 
 class DirectionsTest {
 
-  // ---- movement deltas -----------------------------------------------------
+    // ---- movement deltas -----------------------------------------------------
 
-  @Test
-  void northStepsUpOneRow() {
-    assertEquals(0, Directions.NORTH.dx());
-    assertEquals(-1, Directions.NORTH.dy());
-  }
-
-  @Test
-  void southStepsDownOneRow() {
-    assertEquals(0, Directions.SOUTH.dx());
-    assertEquals(1, Directions.SOUTH.dy());
-  }
-
-  @Test
-  void eastStepsRightOneColumn() {
-    assertEquals(1, Directions.EAST.dx());
-    assertEquals(0, Directions.EAST.dy());
-  }
-
-  @Test
-  void westStepsLeftOneColumn() {
-    assertEquals(-1, Directions.WEST.dx());
-    assertEquals(0, Directions.WEST.dy());
-  }
-
-  // ---- rotation ------------------------------------------------------------
-
-  @Test
-  void turningRightCyclesClockwise() {
-    assertEquals(Directions.EAST, Directions.NORTH.rotate(Orientation.RIGHT));
-    assertEquals(Directions.SOUTH, Directions.EAST.rotate(Orientation.RIGHT));
-    assertEquals(Directions.WEST, Directions.SOUTH.rotate(Orientation.RIGHT));
-    assertEquals(Directions.NORTH, Directions.WEST.rotate(Orientation.RIGHT));
-  }
-
-  @Test
-  void turningLeftCyclesCounterClockwise() {
-    assertEquals(Directions.WEST, Directions.NORTH.rotate(Orientation.LEFT));
-    assertEquals(Directions.SOUTH, Directions.WEST.rotate(Orientation.LEFT));
-    assertEquals(Directions.EAST, Directions.SOUTH.rotate(Orientation.LEFT));
-    assertEquals(Directions.NORTH, Directions.EAST.rotate(Orientation.LEFT));
-  }
-
-  @Test
-  void leftThenRightReturnsToStart() {
-    for (Directions start : Directions.values()) {
-      assertEquals(start, start.rotate(Orientation.LEFT).rotate(Orientation.RIGHT));
+    @Test
+    void northStepsUpOneRow() {
+        assertEquals(0, Directions.NORTH.dx());
+        assertEquals(-1, Directions.NORTH.dy());
     }
-  }
 
-  @Test
-  void fourRightTurnsReturnToStart() {
-    for (Directions start : Directions.values()) {
-      Directions d = start;
-      for (int i = 0; i < 4; i++) {
-        d = d.rotate(Orientation.RIGHT);
-      }
-      assertEquals(start, d);
+    @Test
+    void southStepsDownOneRow() {
+        assertEquals(0, Directions.SOUTH.dx());
+        assertEquals(1, Directions.SOUTH.dy());
     }
-  }
 
-  @Test
-  void leftIsAlwaysTheInverseOfRight() {
-    for (Directions start : Directions.values()) {
-      assertEquals(start.rotate(Orientation.LEFT), start.rotate(Orientation.RIGHT).rotate(Orientation.RIGHT).rotate(Orientation.RIGHT));
+    @Test
+    void eastStepsRightOneColumn() {
+        assertEquals(1, Directions.EAST.dx());
+        assertEquals(0, Directions.EAST.dy());
     }
-  }
+
+    @Test
+    void westStepsLeftOneColumn() {
+        assertEquals(-1, Directions.WEST.dx());
+        assertEquals(0, Directions.WEST.dy());
+    }
+
+    // ---- rotation ------------------------------------------------------------
+
+    @Test
+    void turningRightCyclesClockwise() {
+        assertEquals(Directions.EAST, Directions.NORTH.rotate(Orientation.RIGHT));
+        assertEquals(Directions.SOUTH, Directions.EAST.rotate(Orientation.RIGHT));
+        assertEquals(Directions.WEST, Directions.SOUTH.rotate(Orientation.RIGHT));
+        assertEquals(Directions.NORTH, Directions.WEST.rotate(Orientation.RIGHT));
+    }
+
+    @Test
+    void turningLeftCyclesCounterClockwise() {
+        assertEquals(Directions.WEST, Directions.NORTH.rotate(Orientation.LEFT));
+        assertEquals(Directions.SOUTH, Directions.WEST.rotate(Orientation.LEFT));
+        assertEquals(Directions.EAST, Directions.SOUTH.rotate(Orientation.LEFT));
+        assertEquals(Directions.NORTH, Directions.EAST.rotate(Orientation.LEFT));
+    }
+
+    @Test
+    void leftThenRightReturnsToStart() {
+        for (Directions start : Directions.values()) {
+            assertEquals(start, start.rotate(Orientation.LEFT).rotate(Orientation.RIGHT));
+        }
+    }
+
+    @Test
+    void fourRightTurnsReturnToStart() {
+        for (Directions start : Directions.values()) {
+            Directions d = start;
+            for (int i = 0; i < 4; i++) {
+                d = d.rotate(Orientation.RIGHT);
+            }
+            assertEquals(start, d);
+        }
+    }
+
+    @Test
+    void leftIsAlwaysTheInverseOfRight() {
+        for (Directions start : Directions.values()) {
+            assertEquals(
+                    start.rotate(Orientation.LEFT),
+                    start.rotate(Orientation.RIGHT).rotate(Orientation.RIGHT).rotate(Orientation.RIGHT));
+        }
+    }
 }

--- a/src/test/java/ca/ciccc/silverBullet/enums/gameplay/PlayerActionTest.java
+++ b/src/test/java/ca/ciccc/silverBullet/enums/gameplay/PlayerActionTest.java
@@ -8,23 +8,23 @@ import org.junit.jupiter.api.Test;
 
 class PlayerActionTest {
 
-  @Test
-  void mapsTheFivePlanningKeysToTheirActions() {
-    assertEquals(PlayerAction.TURN_LEFT, PlayerAction.getActionByKeyCode(KeyCode.Q));
-    assertEquals(PlayerAction.MOVE, PlayerAction.getActionByKeyCode(KeyCode.W));
-    assertEquals(PlayerAction.TURN_RIGHT, PlayerAction.getActionByKeyCode(KeyCode.E));
-    assertEquals(PlayerAction.SHOOT, PlayerAction.getActionByKeyCode(KeyCode.R));
-    assertEquals(PlayerAction.WAIT, PlayerAction.getActionByKeyCode(KeyCode.T));
-  }
+    @Test
+    void mapsTheFivePlanningKeysToTheirActions() {
+        assertEquals(PlayerAction.TURN_LEFT, PlayerAction.getActionByKeyCode(KeyCode.Q));
+        assertEquals(PlayerAction.MOVE, PlayerAction.getActionByKeyCode(KeyCode.W));
+        assertEquals(PlayerAction.TURN_RIGHT, PlayerAction.getActionByKeyCode(KeyCode.E));
+        assertEquals(PlayerAction.SHOOT, PlayerAction.getActionByKeyCode(KeyCode.R));
+        assertEquals(PlayerAction.WAIT, PlayerAction.getActionByKeyCode(KeyCode.T));
+    }
 
-  @Test
-  void returnsNullForUnmappedLetterKey() {
-    assertNull(PlayerAction.getActionByKeyCode(KeyCode.A));
-  }
+    @Test
+    void returnsNullForUnmappedLetterKey() {
+        assertNull(PlayerAction.getActionByKeyCode(KeyCode.A));
+    }
 
-  @Test
-  void returnsNullForSpaceWhichIsHandledSeparatelyAsEndTurn() {
-    // SPACE ends the turn in GameScene; it is deliberately not an action.
-    assertNull(PlayerAction.getActionByKeyCode(KeyCode.SPACE));
-  }
+    @Test
+    void returnsNullForSpaceWhichIsHandledSeparatelyAsEndTurn() {
+        // SPACE ends the turn in GameScene; it is deliberately not an action.
+        assertNull(PlayerAction.getActionByKeyCode(KeyCode.SPACE));
+    }
 }

--- a/src/test/java/ca/ciccc/silverBullet/enums/gameplay/WaitTimeTest.java
+++ b/src/test/java/ca/ciccc/silverBullet/enums/gameplay/WaitTimeTest.java
@@ -6,22 +6,22 @@ import org.junit.jupiter.api.Test;
 
 class WaitTimeTest {
 
-  @Test
-  void eachOptionMapsToItsSeconds() {
-    assertEquals(10, WaitTime.SHORT.getSeconds());
-    assertEquals(20, WaitTime.NORMAL.getSeconds());
-    assertEquals(30, WaitTime.LONG.getSeconds());
-  }
+    @Test
+    void eachOptionMapsToItsSeconds() {
+        assertEquals(10, WaitTime.SHORT.getSeconds());
+        assertEquals(20, WaitTime.NORMAL.getSeconds());
+        assertEquals(30, WaitTime.LONG.getSeconds());
+    }
 
-  @Test
-  void labelsIncludeTheDurationForTheComboBox() {
-    assertEquals("Short (10s)", WaitTime.SHORT.toString());
-    assertEquals("Normal (20s)", WaitTime.NORMAL.toString());
-    assertEquals("Long (30s)", WaitTime.LONG.toString());
-  }
+    @Test
+    void labelsIncludeTheDurationForTheComboBox() {
+        assertEquals("Short (10s)", WaitTime.SHORT.toString());
+        assertEquals("Normal (20s)", WaitTime.NORMAL.toString());
+        assertEquals("Long (30s)", WaitTime.LONG.toString());
+    }
 
-  @Test
-  void theDefaultIsNormal() {
-    assertEquals(WaitTime.NORMAL, WaitTime.DEFAULT);
-  }
+    @Test
+    void theDefaultIsNormal() {
+        assertEquals(WaitTime.NORMAL, WaitTime.DEFAULT);
+    }
 }

--- a/src/test/java/ca/ciccc/silverBullet/gameBoard/GameSceneCollisionTest.java
+++ b/src/test/java/ca/ciccc/silverBullet/gameBoard/GameSceneCollisionTest.java
@@ -18,43 +18,43 @@ import org.junit.jupiter.api.Test;
  */
 class GameSceneCollisionTest {
 
-  @BeforeAll
-  static void startJavaFx() throws InterruptedException {
-    JavaFxToolkit.init();
-  }
+    @BeforeAll
+    static void startJavaFx() throws InterruptedException {
+        JavaFxToolkit.init();
+    }
 
-  @Test
-  void twoPlayersTargetingTheSameTileWhileAThirdMovesElsewhere() throws InterruptedException {
-    AtomicReference<GameScene> ref = new AtomicReference<>();
+    @Test
+    void twoPlayersTargetingTheSameTileWhileAThirdMovesElsewhere() throws InterruptedException {
+        AtomicReference<GameScene> ref = new AtomicReference<>();
 
-    JavaFxToolkit.runOnFxThread(() -> {
-      GameScene scene = new GameScene.Builder().player(3).level(1).build();
-      ref.set(scene);
-      GridBoard board = scene.getGameBoard();
+        JavaFxToolkit.runOnFxThread(() -> {
+            GameScene scene = new GameScene.Builder().player(3).level(1).build();
+            ref.set(scene);
+            GridBoard board = scene.getGameBoard();
 
-      // Starts: P0 (2,1), P1 (6,7), P2 (2,7).
-      // P0 and P1 both aim for (4,4); P2 aims for the adjacent (3,7).
-      board.players.get(0).setTargetMove(new Move(4, 4));
-      board.players.get(1).setTargetMove(new Move(4, 4));
-      board.players.get(2).setTargetMove(new Move(3, 7));
+            // Starts: P0 (2,1), P1 (6,7), P2 (2,7).
+            // P0 and P1 both aim for (4,4); P2 aims for the adjacent (3,7).
+            board.players.get(0).setTargetMove(new Move(4, 4));
+            board.players.get(1).setTargetMove(new Move(4, 4));
+            board.players.get(2).setTargetMove(new Move(3, 7));
 
-      scene.executeMove();
-    });
+            scene.executeMove();
+        });
 
-    GridBoard board = ref.get().getGameBoard();
-    Player p0 = board.players.get(0);
-    Player p1 = board.players.get(1);
-    Player p2 = board.players.get(2);
+        GridBoard board = ref.get().getGameBoard();
+        Player p0 = board.players.get(0);
+        Player p1 = board.players.get(1);
+        Player p2 = board.players.get(2);
 
-    // The colliding pair must stay put...
-    assertEquals(2, p0.getGridPositionX(), "P0 should not move into the contested tile");
-    assertEquals(1, p0.getGridPositionY());
-    assertEquals(6, p1.getGridPositionX(), "P1 should not move into the contested tile");
-    assertEquals(7, p1.getGridPositionY());
-    assertFalse(board.getNodeFromGrid(4, 4).hasPlayer(), "the contested tile stays empty");
+        // The colliding pair must stay put...
+        assertEquals(2, p0.getGridPositionX(), "P0 should not move into the contested tile");
+        assertEquals(1, p0.getGridPositionY());
+        assertEquals(6, p1.getGridPositionX(), "P1 should not move into the contested tile");
+        assertEquals(7, p1.getGridPositionY());
+        assertFalse(board.getNodeFromGrid(4, 4).hasPlayer(), "the contested tile stays empty");
 
-    // ...while the non-colliding player moves normally.
-    assertEquals(3, p2.getGridPositionX());
-    assertEquals(7, p2.getGridPositionY());
-  }
+        // ...while the non-colliding player moves normally.
+        assertEquals(3, p2.getGridPositionX());
+        assertEquals(7, p2.getGridPositionY());
+    }
 }

--- a/src/test/java/ca/ciccc/silverBullet/gameBoard/GameSceneExecuteTest.java
+++ b/src/test/java/ca/ciccc/silverBullet/gameBoard/GameSceneExecuteTest.java
@@ -21,55 +21,55 @@ import org.junit.jupiter.api.Test;
  */
 class GameSceneExecuteTest {
 
-  /** Enough boardUpdate ticks to resolve all five action steps (~26 ticks each). */
-  private static final int EXECUTE_TICKS = 160;
+    /** Enough boardUpdate ticks to resolve all five action steps (~26 ticks each). */
+    private static final int EXECUTE_TICKS = 160;
 
-  @BeforeAll
-  static void startJavaFx() throws InterruptedException {
-    JavaFxToolkit.init();
-  }
+    @BeforeAll
+    static void startJavaFx() throws InterruptedException {
+        JavaFxToolkit.init();
+    }
 
-  @Test
-  void aQueuedTurnThenMoveResolvesDuringExecution() throws InterruptedException {
-    AtomicReference<GameScene> ref = new AtomicReference<>();
+    @Test
+    void aQueuedTurnThenMoveResolvesDuringExecution() throws InterruptedException {
+        AtomicReference<GameScene> ref = new AtomicReference<>();
 
-    JavaFxToolkit.runOnFxThread(() -> {
-      GameScene scene = new GameScene.Builder().player(2).level(1).build();
-      scene.setPrompter((title, message, onConfirm) -> onConfirm.run()); // auto-confirm
-      ref.set(scene);
+        JavaFxToolkit.runOnFxThread(() -> {
+            GameScene scene = new GameScene.Builder().player(2).level(1).build();
+            scene.setPrompter((title, message, onConfirm) -> onConfirm.run()); // auto-confirm
+            ref.set(scene);
 
-      // Player 1 (index 0) starts at (2,1) facing SOUTH. Queue: turn right (-> WEST),
-      // then move (-> (1,1)), then wait out the turn.
-      scene.onKeyPressed(KeyCode.E); // TURN_RIGHT
-      scene.onKeyPressed(KeyCode.W); // MOVE
-      scene.onKeyPressed(KeyCode.T); // WAIT
-      scene.onKeyPressed(KeyCode.T); // WAIT
-      scene.onKeyPressed(KeyCode.T); // WAIT
-      scene.onKeyPressed(KeyCode.SPACE); // end player 1's turn
+            // Player 1 (index 0) starts at (2,1) facing SOUTH. Queue: turn right (-> WEST),
+            // then move (-> (1,1)), then wait out the turn.
+            scene.onKeyPressed(KeyCode.E); // TURN_RIGHT
+            scene.onKeyPressed(KeyCode.W); // MOVE
+            scene.onKeyPressed(KeyCode.T); // WAIT
+            scene.onKeyPressed(KeyCode.T); // WAIT
+            scene.onKeyPressed(KeyCode.T); // WAIT
+            scene.onKeyPressed(KeyCode.SPACE); // end player 1's turn
 
-      // Player 2 (index 1) just waits its whole turn.
-      for (int i = 0; i < 5; i++) {
-        scene.onKeyPressed(KeyCode.T);
-      }
-      scene.onKeyPressed(KeyCode.SPACE); // both full -> execution begins
+            // Player 2 (index 1) just waits its whole turn.
+            for (int i = 0; i < 5; i++) {
+                scene.onKeyPressed(KeyCode.T);
+            }
+            scene.onKeyPressed(KeyCode.SPACE); // both full -> execution begins
 
-      // Step the execution phase to completion.
-      for (int tick = 0; tick < EXECUTE_TICKS; tick++) {
-        scene.boardUpdate();
-      }
-    });
+            // Step the execution phase to completion.
+            for (int tick = 0; tick < EXECUTE_TICKS; tick++) {
+                scene.boardUpdate();
+            }
+        });
 
-    GameScene scene = ref.get();
-    Player planner = scene.getGameBoard().players.get(0);
-    Player waiter = scene.getGameBoard().players.get(1);
+        GameScene scene = ref.get();
+        Player planner = scene.getGameBoard().players.get(0);
+        Player waiter = scene.getGameBoard().players.get(1);
 
-    // The turn-then-move resolved: player 1 turned WEST and advanced one tile.
-    assertEquals(Directions.WEST, planner.getFacingDirection(), "TURN_RIGHT should face WEST");
-    assertEquals(1, planner.getGridPositionX(), "MOVE west should reach column 1");
-    assertEquals(1, planner.getGridPositionY(), "row is unchanged by a westward move");
+        // The turn-then-move resolved: player 1 turned WEST and advanced one tile.
+        assertEquals(Directions.WEST, planner.getFacingDirection(), "TURN_RIGHT should face WEST");
+        assertEquals(1, planner.getGridPositionX(), "MOVE west should reach column 1");
+        assertEquals(1, planner.getGridPositionY(), "row is unchanged by a westward move");
 
-    // The waiting player did not move.
-    assertEquals(6, waiter.getGridPositionX());
-    assertEquals(7, waiter.getGridPositionY());
-  }
+        // The waiting player did not move.
+        assertEquals(6, waiter.getGridPositionX());
+        assertEquals(7, waiter.getGridPositionY());
+    }
 }

--- a/src/test/java/ca/ciccc/silverBullet/gameBoard/GameSceneGameOverTest.java
+++ b/src/test/java/ca/ciccc/silverBullet/gameBoard/GameSceneGameOverTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ca.ciccc.silverBullet.extraScreens.GameOverScreen;
-import ca.ciccc.silverBullet.playerElements.Player;
 import ca.ciccc.silverBullet.testsupport.JavaFxToolkit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -20,59 +19,59 @@ import org.junit.jupiter.api.Test;
  */
 class GameSceneGameOverTest {
 
-  @BeforeAll
-  static void startJavaFx() throws InterruptedException {
-    JavaFxToolkit.init();
-  }
+    @BeforeAll
+    static void startJavaFx() throws InterruptedException {
+        JavaFxToolkit.init();
+    }
 
-  private static boolean showsGameOver(GameScene scene) {
-    return scene.getChildren().stream().anyMatch(node -> node instanceof GameOverScreen);
-  }
+    private static boolean showsGameOver(GameScene scene) {
+        return scene.getChildren().stream().anyMatch(node -> node instanceof GameOverScreen);
+    }
 
-  @Test
-  void eliminatingDownToOnePlayerEndsTheGame() throws InterruptedException {
-    AtomicReference<GameScene> ref = new AtomicReference<>();
+    @Test
+    void eliminatingDownToOnePlayerEndsTheGame() throws InterruptedException {
+        AtomicReference<GameScene> ref = new AtomicReference<>();
 
-    JavaFxToolkit.runOnFxThread(() -> {
-      GameScene scene = new GameScene.Builder().player(2).level(1).build();
-      ref.set(scene);
-      GridBoard board = scene.getGameBoard();
-      board.removePlayer(board.players.get(1)); // player 2 is knocked out
-    });
+        JavaFxToolkit.runOnFxThread(() -> {
+            GameScene scene = new GameScene.Builder().player(2).level(1).build();
+            ref.set(scene);
+            GridBoard board = scene.getGameBoard();
+            board.removePlayer(board.players.get(1)); // player 2 is knocked out
+        });
 
-    GameScene scene = ref.get();
-    assertEquals(1, scene.getGameBoard().players.size(), "one survivor remains");
-    assertEquals(1, scene.getGameBoard().players.get(0).getPlayerNumber(), "player 1 survives");
-    assertTrue(showsGameOver(scene), "a game-over screen should be shown");
-  }
+        GameScene scene = ref.get();
+        assertEquals(1, scene.getGameBoard().players.size(), "one survivor remains");
+        assertEquals(1, scene.getGameBoard().players.get(0).getPlayerNumber(), "player 1 survives");
+        assertTrue(showsGameOver(scene), "a game-over screen should be shown");
+    }
 
-  @Test
-  void gameOverStopsTheInjectedGameLoop() throws InterruptedException {
-    AtomicBoolean stopped = new AtomicBoolean(false);
+    @Test
+    void gameOverStopsTheInjectedGameLoop() throws InterruptedException {
+        AtomicBoolean stopped = new AtomicBoolean(false);
 
-    JavaFxToolkit.runOnFxThread(() -> {
-      GameScene scene = new GameScene.Builder().player(2).level(1).build();
-      scene.setOnStop(() -> stopped.set(true));
-      GridBoard board = scene.getGameBoard();
-      board.removePlayer(board.players.get(1)); // triggers game over
-    });
+        JavaFxToolkit.runOnFxThread(() -> {
+            GameScene scene = new GameScene.Builder().player(2).level(1).build();
+            scene.setOnStop(() -> stopped.set(true));
+            GridBoard board = scene.getGameBoard();
+            board.removePlayer(board.players.get(1)); // triggers game over
+        });
 
-    assertTrue(stopped.get(), "the game loop should be stopped when the game ends");
-  }
+        assertTrue(stopped.get(), "the game loop should be stopped when the game ends");
+    }
 
-  @Test
-  void eliminatingOneOfThreePlayersContinuesTheGame() throws InterruptedException {
-    AtomicReference<GameScene> ref = new AtomicReference<>();
+    @Test
+    void eliminatingOneOfThreePlayersContinuesTheGame() throws InterruptedException {
+        AtomicReference<GameScene> ref = new AtomicReference<>();
 
-    JavaFxToolkit.runOnFxThread(() -> {
-      GameScene scene = new GameScene.Builder().player(3).level(1).build();
-      ref.set(scene);
-      GridBoard board = scene.getGameBoard();
-      board.removePlayer(board.players.get(0));
-    });
+        JavaFxToolkit.runOnFxThread(() -> {
+            GameScene scene = new GameScene.Builder().player(3).level(1).build();
+            ref.set(scene);
+            GridBoard board = scene.getGameBoard();
+            board.removePlayer(board.players.get(0));
+        });
 
-    GameScene scene = ref.get();
-    assertEquals(2, scene.getGameBoard().players.size(), "two players remain");
-    assertFalse(showsGameOver(scene), "the game should not be over yet");
-  }
+        GameScene scene = ref.get();
+        assertEquals(2, scene.getGameBoard().players.size(), "two players remain");
+        assertFalse(showsGameOver(scene), "the game should not be over yet");
+    }
 }

--- a/src/test/java/ca/ciccc/silverBullet/gameBoard/GameSceneStaleMoveTest.java
+++ b/src/test/java/ca/ciccc/silverBullet/gameBoard/GameSceneStaleMoveTest.java
@@ -19,60 +19,60 @@ import org.junit.jupiter.api.Test;
  */
 class GameSceneStaleMoveTest {
 
-  @BeforeAll
-  static void startJavaFx() throws InterruptedException {
-    JavaFxToolkit.init();
-  }
+    @BeforeAll
+    static void startJavaFx() throws InterruptedException {
+        JavaFxToolkit.init();
+    }
 
-  /** Relocate a player onto a specific tile, keeping the grid consistent. */
-  private static void placeAt(GridBoard board, Player player, int x, int y, Directions facing) {
-    board.getNodeFromGrid(player.getGridPositionX(), player.getGridPositionY())
-        .setPlayerInSpace(null);
-    board.getNodeFromGrid(x, y).setPlayerInSpace(player);
-    player.setGridPositionX(x);
-    player.setGridPositionY(y);
-    player.setFacingDirection(facing);
-  }
+    /** Relocate a player onto a specific tile, keeping the grid consistent. */
+    private static void placeAt(GridBoard board, Player player, int x, int y, Directions facing) {
+        board.getNodeFromGrid(player.getGridPositionX(), player.getGridPositionY())
+                .setPlayerInSpace(null);
+        board.getNodeFromGrid(x, y).setPlayerInSpace(player);
+        player.setGridPositionX(x);
+        player.setGridPositionY(y);
+        player.setFacingDirection(facing);
+    }
 
-  private static PlayerAction[] moveThenWait() {
-    return new PlayerAction[] {
-        PlayerAction.MOVE, PlayerAction.WAIT, PlayerAction.WAIT, PlayerAction.WAIT, PlayerAction.WAIT
-    };
-  }
+    private static PlayerAction[] moveThenWait() {
+        return new PlayerAction[] {
+            PlayerAction.MOVE, PlayerAction.WAIT, PlayerAction.WAIT, PlayerAction.WAIT, PlayerAction.WAIT
+        };
+    }
 
-  @Test
-  void aBlockedMoveDoesNotResolveOnALaterWaitStep() throws InterruptedException {
-    AtomicReference<GameScene> ref = new AtomicReference<>();
+    @Test
+    void aBlockedMoveDoesNotResolveOnALaterWaitStep() throws InterruptedException {
+        AtomicReference<GameScene> ref = new AtomicReference<>();
 
-    JavaFxToolkit.runOnFxThread(() -> {
-      GameScene scene = new GameScene.Builder().player(2).level(1).build();
-      ref.set(scene);
-      GridBoard board = scene.getGameBoard();
-      Player a = board.players.get(0);
-      Player b = board.players.get(1);
+        JavaFxToolkit.runOnFxThread(() -> {
+            GameScene scene = new GameScene.Builder().player(2).level(1).build();
+            ref.set(scene);
+            GridBoard board = scene.getGameBoard();
+            Player a = board.players.get(0);
+            Player b = board.players.get(1);
 
-      // Face each other across the open tile (4,2): A at (3,2) heading east,
-      // B at (5,2) heading west. Both queue MOVE first, then wait.
-      placeAt(board, a, 3, 2, Directions.EAST);
-      placeAt(board, b, 5, 2, Directions.WEST);
-      a.setPlayerActions(moveThenWait());
-      b.setPlayerActions(moveThenWait());
+            // Face each other across the open tile (4,2): A at (3,2) heading east,
+            // B at (5,2) heading west. Both queue MOVE first, then wait.
+            placeAt(board, a, 3, 2, Directions.EAST);
+            placeAt(board, b, 5, 2, Directions.WEST);
+            a.setPlayerActions(moveThenWait());
+            b.setPlayerActions(moveThenWait());
 
-      // Step 0 (MOVE): both target (4,2) and collide, so neither moves.
-      a.takeAction(0);
-      b.takeAction(0);
-      scene.executeMove();
+            // Step 0 (MOVE): both target (4,2) and collide, so neither moves.
+            a.takeAction(0);
+            b.takeAction(0);
+            scene.executeMove();
 
-      // B leaves the contest (e.g. eliminated); A merely waits next step.
-      board.players.remove(b);
+            // B leaves the contest (e.g. eliminated); A merely waits next step.
+            board.players.remove(b);
 
-      // Step 1 (WAIT): A does nothing this step.
-      a.takeAction(1);
-      scene.executeMove();
-    });
+            // Step 1 (WAIT): A does nothing this step.
+            a.takeAction(1);
+            scene.executeMove();
+        });
 
-    Player a = ref.get().getGameBoard().players.get(0);
-    assertEquals(3, a.getGridPositionX(), "a waiting player must not move onto the old blocked tile");
-    assertEquals(2, a.getGridPositionY());
-  }
+        Player a = ref.get().getGameBoard().players.get(0);
+        assertEquals(3, a.getGridPositionX(), "a waiting player must not move onto the old blocked tile");
+        assertEquals(2, a.getGridPositionY());
+    }
 }

--- a/src/test/java/ca/ciccc/silverBullet/gameBoard/GameSceneTurnSmokeTest.java
+++ b/src/test/java/ca/ciccc/silverBullet/gameBoard/GameSceneTurnSmokeTest.java
@@ -25,58 +25,61 @@ import org.junit.jupiter.api.Test;
  */
 class GameSceneTurnSmokeTest {
 
-  @BeforeAll
-  static void startJavaFx() throws InterruptedException {
-    JavaFxToolkit.init();
-  }
+    @BeforeAll
+    static void startJavaFx() throws InterruptedException {
+        JavaFxToolkit.init();
+    }
 
-  private static GameScene buildScene(int players, int level) throws InterruptedException {
-    AtomicReference<GameScene> scene = new AtomicReference<>();
-    JavaFxToolkit.runOnFxThread(
-        () -> scene.set(new GameScene.Builder().player(players).level(level).build()));
-    return scene.get();
-  }
+    private static GameScene buildScene(int players, int level) throws InterruptedException {
+        AtomicReference<GameScene> scene = new AtomicReference<>();
+        JavaFxToolkit.runOnFxThread(() ->
+                scene.set(new GameScene.Builder().player(players).level(level).build()));
+        return scene.get();
+    }
 
-  @Test
-  void buildsAFullyAssembledSceneForTwoPlayers() throws InterruptedException {
-    GameScene scene = buildScene(2, 1);
+    @Test
+    void buildsAFullyAssembledSceneForTwoPlayers() throws InterruptedException {
+        GameScene scene = buildScene(2, 1);
 
-    assertFalse(scene.getChildren().isEmpty(), "scene graph should be populated");
-    assertEquals(2, scene.getGameBoard().players.size(), "both players should be on the board");
-  }
+        assertFalse(scene.getChildren().isEmpty(), "scene graph should be populated");
+        assertEquals(2, scene.getGameBoard().players.size(), "both players should be on the board");
+    }
 
-  @Test
-  void planningKeysFillTheControlledPlayersActionQueue() throws InterruptedException {
-    GameScene scene = buildScene(2, 1);
+    @Test
+    void planningKeysFillTheControlledPlayersActionQueue() throws InterruptedException {
+        GameScene scene = buildScene(2, 1);
 
-    JavaFxToolkit.runOnFxThread(() -> {
-      scene.onKeyPressed(KeyCode.Q); // TURN_LEFT
-      scene.onKeyPressed(KeyCode.W); // MOVE
-      scene.onKeyPressed(KeyCode.E); // TURN_RIGHT
-      scene.onKeyPressed(KeyCode.R); // SHOOT
-      scene.onKeyPressed(KeyCode.T); // WAIT
-    });
+        JavaFxToolkit.runOnFxThread(() -> {
+            scene.onKeyPressed(KeyCode.Q); // TURN_LEFT
+            scene.onKeyPressed(KeyCode.W); // MOVE
+            scene.onKeyPressed(KeyCode.E); // TURN_RIGHT
+            scene.onKeyPressed(KeyCode.R); // SHOOT
+            scene.onKeyPressed(KeyCode.T); // WAIT
+        });
 
-    Player controlled = scene.getGameBoard().players.get(0);
-    assertTrue(controlled.isActionsFull(), "five actions should fill the queue");
-    assertArrayEquals(
-        new PlayerAction[] {
-            PlayerAction.TURN_LEFT, PlayerAction.MOVE, PlayerAction.TURN_RIGHT,
-            PlayerAction.SHOOT, PlayerAction.WAIT
-        },
-        controlled.getPlayerActions());
-  }
+        Player controlled = scene.getGameBoard().players.get(0);
+        assertTrue(controlled.isActionsFull(), "five actions should fill the queue");
+        assertArrayEquals(
+                new PlayerAction[] {
+                    PlayerAction.TURN_LEFT,
+                    PlayerAction.MOVE,
+                    PlayerAction.TURN_RIGHT,
+                    PlayerAction.SHOOT,
+                    PlayerAction.WAIT
+                },
+                controlled.getPlayerActions());
+    }
 
-  @Test
-  void planningOnlyAffectsTheCurrentPlayerNotTheNextOne() throws InterruptedException {
-    GameScene scene = buildScene(2, 1);
+    @Test
+    void planningOnlyAffectsTheCurrentPlayerNotTheNextOne() throws InterruptedException {
+        GameScene scene = buildScene(2, 1);
 
-    JavaFxToolkit.runOnFxThread(() -> scene.onKeyPressed(KeyCode.W)); // MOVE for player 0 only
+        JavaFxToolkit.runOnFxThread(() -> scene.onKeyPressed(KeyCode.W)); // MOVE for player 0 only
 
-    Player first = scene.getGameBoard().players.get(0);
-    Player second = scene.getGameBoard().players.get(1);
-    assertEquals(PlayerAction.MOVE, first.getPlayerActions()[0]);
-    assertFalse(first.isActionsFull());
-    assertEquals(PlayerAction.NONE, second.getPlayerActions()[0], "the other player is untouched");
-  }
+        Player first = scene.getGameBoard().players.get(0);
+        Player second = scene.getGameBoard().players.get(1);
+        assertEquals(PlayerAction.MOVE, first.getPlayerActions()[0]);
+        assertFalse(first.isActionsFull());
+        assertEquals(PlayerAction.NONE, second.getPlayerActions()[0], "the other player is untouched");
+    }
 }

--- a/src/test/java/ca/ciccc/silverBullet/gameBoard/GameSceneWaitTimeTest.java
+++ b/src/test/java/ca/ciccc/silverBullet/gameBoard/GameSceneWaitTimeTest.java
@@ -11,31 +11,31 @@ import org.junit.jupiter.api.Test;
 /** The configured wait time seeds the planning-phase countdown. */
 class GameSceneWaitTimeTest {
 
-  @BeforeAll
-  static void startJavaFx() throws InterruptedException {
-    JavaFxToolkit.init();
-  }
+    @BeforeAll
+    static void startJavaFx() throws InterruptedException {
+        JavaFxToolkit.init();
+    }
 
-  private static double buildAndReadTimer(Integer turnSeconds) throws InterruptedException {
-    AtomicReference<GameScene> ref = new AtomicReference<>();
-    JavaFxToolkit.runOnFxThread(() -> {
-      GameScene.Builder builder = new GameScene.Builder().player(2).level(1);
-      if (turnSeconds != null) {
-        builder.turnSeconds(turnSeconds);
-      }
-      ref.set(builder.build());
-    });
-    return ref.get().getTurnTimer();
-  }
+    private static double buildAndReadTimer(Integer turnSeconds) throws InterruptedException {
+        AtomicReference<GameScene> ref = new AtomicReference<>();
+        JavaFxToolkit.runOnFxThread(() -> {
+            GameScene.Builder builder = new GameScene.Builder().player(2).level(1);
+            if (turnSeconds != null) {
+                builder.turnSeconds(turnSeconds);
+            }
+            ref.set(builder.build());
+        });
+        return ref.get().getTurnTimer();
+    }
 
-  @Test
-  void theCountdownStartsAtTheChosenWaitTime() throws InterruptedException {
-    assertEquals(WaitTime.LONG.getSeconds(), buildAndReadTimer(WaitTime.LONG.getSeconds()));
-    assertEquals(WaitTime.NORMAL.getSeconds(), buildAndReadTimer(WaitTime.NORMAL.getSeconds()));
-  }
+    @Test
+    void theCountdownStartsAtTheChosenWaitTime() throws InterruptedException {
+        assertEquals(WaitTime.LONG.getSeconds(), buildAndReadTimer(WaitTime.LONG.getSeconds()));
+        assertEquals(WaitTime.NORMAL.getSeconds(), buildAndReadTimer(WaitTime.NORMAL.getSeconds()));
+    }
 
-  @Test
-  void itDefaultsToTenSecondsWhenUnset() throws InterruptedException {
-    assertEquals(10.0, buildAndReadTimer(null));
-  }
+    @Test
+    void itDefaultsToTenSecondsWhenUnset() throws InterruptedException {
+        assertEquals(10.0, buildAndReadTimer(null));
+    }
 }

--- a/src/test/java/ca/ciccc/silverBullet/gameBoard/GridBoardDetachPlayerTest.java
+++ b/src/test/java/ca/ciccc/silverBullet/gameBoard/GridBoardDetachPlayerTest.java
@@ -22,53 +22,53 @@ import org.junit.jupiter.api.Test;
  */
 class GridBoardDetachPlayerTest {
 
-  private static final int BOARD = 9;
+    private static final int BOARD = 9;
 
-  @BeforeAll
-  static void startJavaFx() throws InterruptedException {
-    JavaFxToolkit.init();
-  }
+    @BeforeAll
+    static void startJavaFx() throws InterruptedException {
+        JavaFxToolkit.init();
+    }
 
-  @Test
-  void clearsTheTileThePlayerActuallyStandsOn() {
-    GridBoard board = new GridBoard(BOARD, BOARD, 1);
-    Player standing = board.addPlayer(2, 1, 1);   // asymmetric: x=2, y=1
-    board.addPlayer(6, 7, 2);                      // a second player so one survives
+    @Test
+    void clearsTheTileThePlayerActuallyStandsOn() {
+        GridBoard board = new GridBoard(BOARD, BOARD, 1);
+        Player standing = board.addPlayer(2, 1, 1); // asymmetric: x=2, y=1
+        board.addPlayer(6, 7, 2); // a second player so one survives
 
-    // Precondition: (2,1) is occupied and the transposed tile (1,2) is not.
-    assertTrue(board.getNodeFromGrid(2, 1).hasPlayer(), "player's own tile should start occupied");
-    assertFalse(board.getNodeFromGrid(1, 2).hasPlayer(), "transposed tile should be empty");
+        // Precondition: (2,1) is occupied and the transposed tile (1,2) is not.
+        assertTrue(board.getNodeFromGrid(2, 1).hasPlayer(), "player's own tile should start occupied");
+        assertFalse(board.getNodeFromGrid(1, 2).hasPlayer(), "transposed tile should be empty");
 
-    board.detachPlayerFromBoard(standing);
+        board.detachPlayerFromBoard(standing);
 
-    // The tile the player stood on must be cleared. Under the old grid[x][y]
-    // bug this stayed occupied because grid[2][1] (i.e. tile (1,2)) was cleared.
-    assertFalse(board.getNodeFromGrid(2, 1).hasPlayer(), "player's tile must be cleared on removal");
-    assertFalse(board.players.contains(standing), "player must be dropped from the roster");
-  }
+        // The tile the player stood on must be cleared. Under the old grid[x][y]
+        // bug this stayed occupied because grid[2][1] (i.e. tile (1,2)) was cleared.
+        assertFalse(board.getNodeFromGrid(2, 1).hasPlayer(), "player's tile must be cleared on removal");
+        assertFalse(board.players.contains(standing), "player must be dropped from the roster");
+    }
 
-  @Test
-  void reportsTheSoleSurvivorAsTheWinner() {
-    GridBoard board = new GridBoard(BOARD, BOARD, 1);
-    Player one = board.addPlayer(2, 1, 1);
-    board.addPlayer(6, 7, 2);
+    @Test
+    void reportsTheSoleSurvivorAsTheWinner() {
+        GridBoard board = new GridBoard(BOARD, BOARD, 1);
+        Player one = board.addPlayer(2, 1, 1);
+        board.addPlayer(6, 7, 2);
 
-    OptionalInt winner = board.detachPlayerFromBoard(one);
+        OptionalInt winner = board.detachPlayerFromBoard(one);
 
-    assertTrue(winner.isPresent(), "one player left means the game is over");
-    assertEquals(2, winner.getAsInt(), "the remaining player wins");
-  }
+        assertTrue(winner.isPresent(), "one player left means the game is over");
+        assertEquals(2, winner.getAsInt(), "the remaining player wins");
+    }
 
-  @Test
-  void reportsNoWinnerWhileMoreThanOnePlayerRemains() {
-    GridBoard board = new GridBoard(BOARD, BOARD, 1);
-    Player one = board.addPlayer(2, 1, 1);
-    board.addPlayer(6, 7, 2);
-    board.addPlayer(2, 7, 3);
+    @Test
+    void reportsNoWinnerWhileMoreThanOnePlayerRemains() {
+        GridBoard board = new GridBoard(BOARD, BOARD, 1);
+        Player one = board.addPlayer(2, 1, 1);
+        board.addPlayer(6, 7, 2);
+        board.addPlayer(2, 7, 3);
 
-    OptionalInt winner = board.detachPlayerFromBoard(one);
+        OptionalInt winner = board.detachPlayerFromBoard(one);
 
-    assertFalse(winner.isPresent(), "two players remain, so the game continues");
-    assertEquals(2, board.players.size());
-  }
+        assertFalse(winner.isPresent(), "two players remain, so the game continues");
+        assertEquals(2, board.players.size());
+    }
 }

--- a/src/test/java/ca/ciccc/silverBullet/gameBoard/GridBoardMoveShootTest.java
+++ b/src/test/java/ca/ciccc/silverBullet/gameBoard/GridBoardMoveShootTest.java
@@ -30,90 +30,90 @@ import org.junit.jupiter.api.Test;
  */
 class GridBoardMoveShootTest {
 
-  private static final int BOARD = 9;
+    private static final int BOARD = 9;
 
-  @BeforeAll
-  static void startJavaFx() throws InterruptedException {
-    JavaFxToolkit.init();
-  }
+    @BeforeAll
+    static void startJavaFx() throws InterruptedException {
+        JavaFxToolkit.init();
+    }
 
-  private static Player place(GridBoard board, int x, int y, int number, Directions facing) {
-    Player player = board.addPlayer(x, y, number);
-    player.setFacingDirection(facing);
-    return player;
-  }
+    private static Player place(GridBoard board, int x, int y, int number, Directions facing) {
+        Player player = board.addPlayer(x, y, number);
+        player.setFacingDirection(facing);
+        return player;
+    }
 
-  private static void assertMove(int expectedX, int expectedY, Move move) {
-    assertEquals(expectedX, move.getMoveX(), "moveX");
-    assertEquals(expectedY, move.getMoveY(), "moveY");
-  }
+    private static void assertMove(int expectedX, int expectedY, Move move) {
+        assertEquals(expectedX, move.getMoveX(), "moveX");
+        assertEquals(expectedY, move.getMoveY(), "moveY");
+    }
 
-  // ---- tryMovePlayer -------------------------------------------------------
+    // ---- tryMovePlayer -------------------------------------------------------
 
-  @Test
-  void movesOntoTheAdjacentOpenTile() {
-    GridBoard board = new GridBoard(BOARD, BOARD, 1);
-    Player player = place(board, 1, 2, 1, Directions.EAST);
+    @Test
+    void movesOntoTheAdjacentOpenTile() {
+        GridBoard board = new GridBoard(BOARD, BOARD, 1);
+        Player player = place(board, 1, 2, 1, Directions.EAST);
 
-    assertMove(2, 2, board.tryMovePlayer(player));
-  }
+        assertMove(2, 2, board.tryMovePlayer(player));
+    }
 
-  @Test
-  void movementIsBlockedByAWall() {
-    GridBoard board = new GridBoard(BOARD, BOARD, 1);
-    Player player = place(board, 1, 3, 1, Directions.EAST); // wall sits at (2,3)
+    @Test
+    void movementIsBlockedByAWall() {
+        GridBoard board = new GridBoard(BOARD, BOARD, 1);
+        Player player = place(board, 1, 3, 1, Directions.EAST); // wall sits at (2,3)
 
-    assertNull(board.tryMovePlayer(player));
-  }
+        assertNull(board.tryMovePlayer(player));
+    }
 
-  @Test
-  void movementIsBlockedByTheBoardEdge() {
-    GridBoard board = new GridBoard(BOARD, BOARD, 1);
-    Player player = place(board, 0, 4, 1, Directions.WEST); // would step off the left edge
+    @Test
+    void movementIsBlockedByTheBoardEdge() {
+        GridBoard board = new GridBoard(BOARD, BOARD, 1);
+        Player player = place(board, 0, 4, 1, Directions.WEST); // would step off the left edge
 
-    assertNull(board.tryMovePlayer(player));
-  }
+        assertNull(board.tryMovePlayer(player));
+    }
 
-  @Test
-  void movementIsBlockedByAnotherPlayer() {
-    GridBoard board = new GridBoard(BOARD, BOARD, 1);
-    Player mover = place(board, 4, 2, 1, Directions.SOUTH);
-    place(board, 4, 3, 2, Directions.NORTH); // occupies the target tile
+    @Test
+    void movementIsBlockedByAnotherPlayer() {
+        GridBoard board = new GridBoard(BOARD, BOARD, 1);
+        Player mover = place(board, 4, 2, 1, Directions.SOUTH);
+        place(board, 4, 3, 2, Directions.NORTH); // occupies the target tile
 
-    assertNull(board.tryMovePlayer(mover));
-  }
+        assertNull(board.tryMovePlayer(mover));
+    }
 
-  // ---- tryShoot ------------------------------------------------------------
+    // ---- tryShoot ------------------------------------------------------------
 
-  @Test
-  void shotTravelsAcrossOpenGroundToTheFarEdge() {
-    GridBoard board = new GridBoard(BOARD, BOARD, 1);
-    Player shooter = place(board, 1, 2, 1, Directions.EAST); // row 2 is fully open
+    @Test
+    void shotTravelsAcrossOpenGroundToTheFarEdge() {
+        GridBoard board = new GridBoard(BOARD, BOARD, 1);
+        Player shooter = place(board, 1, 2, 1, Directions.EAST); // row 2 is fully open
 
-    assertMove(8, 2, board.tryShoot(shooter));
-  }
+        assertMove(8, 2, board.tryShoot(shooter));
+    }
 
-  @Test
-  void shotStopsOnTheLastTileBeforeAWall() {
-    GridBoard board = new GridBoard(BOARD, BOARD, 1);
-    Player shooter = place(board, 3, 3, 1, Directions.EAST); // wall at (6,3); (4,3),(5,3) open
+    @Test
+    void shotStopsOnTheLastTileBeforeAWall() {
+        GridBoard board = new GridBoard(BOARD, BOARD, 1);
+        Player shooter = place(board, 3, 3, 1, Directions.EAST); // wall at (6,3); (4,3),(5,3) open
 
-    assertMove(5, 3, board.tryShoot(shooter));
-  }
+        assertMove(5, 3, board.tryShoot(shooter));
+    }
 
-  @Test
-  void shotAtAnAdjacentWallGoesNowhere() {
-    GridBoard board = new GridBoard(BOARD, BOARD, 1);
-    Player shooter = place(board, 1, 3, 1, Directions.EAST); // wall immediately at (2,3)
+    @Test
+    void shotAtAnAdjacentWallGoesNowhere() {
+        GridBoard board = new GridBoard(BOARD, BOARD, 1);
+        Player shooter = place(board, 1, 3, 1, Directions.EAST); // wall immediately at (2,3)
 
-    assertNull(board.tryShoot(shooter));
-  }
+        assertNull(board.tryShoot(shooter));
+    }
 
-  @Test
-  void aPlayerWithNoAmmoCannotShoot() {
-    GridBoard board = new GridBoard(BOARD, BOARD, 1);
-    Player unarmed = new Player(0, 1, 3, 3, Directions.EAST, null); // zero shots
+    @Test
+    void aPlayerWithNoAmmoCannotShoot() {
+        GridBoard board = new GridBoard(BOARD, BOARD, 1);
+        Player unarmed = new Player(0, 1, 3, 3, Directions.EAST, null); // zero shots
 
-    assertNull(board.tryShoot(unarmed));
-  }
+        assertNull(board.tryShoot(unarmed));
+    }
 }

--- a/src/test/java/ca/ciccc/silverBullet/gameBoard/GridBoardPickupTest.java
+++ b/src/test/java/ca/ciccc/silverBullet/gameBoard/GridBoardPickupTest.java
@@ -21,59 +21,59 @@ import org.junit.jupiter.api.Test;
  */
 class GridBoardPickupTest {
 
-  private static final int BOARD = 9;
-  private static final int PICKUP_X = 4;
-  private static final int PICKUP_Y = 4;
+    private static final int BOARD = 9;
+    private static final int PICKUP_X = 4;
+    private static final int PICKUP_Y = 4;
 
-  @BeforeAll
-  static void startJavaFx() throws InterruptedException {
-    JavaFxToolkit.init();
-  }
+    @BeforeAll
+    static void startJavaFx() throws InterruptedException {
+        JavaFxToolkit.init();
+    }
 
-  private static Player movingPlayer(int shots) {
-    Player player = new Player(shots, 1, 3, PICKUP_Y, Directions.EAST, null); // start at (3,4)
-    player.setTargetMove(new Move(PICKUP_X, PICKUP_Y));
-    return player;
-  }
+    private static Player movingPlayer(int shots) {
+        Player player = new Player(shots, 1, 3, PICKUP_Y, Directions.EAST, null); // start at (3,4)
+        player.setTargetMove(new Move(PICKUP_X, PICKUP_Y));
+        return player;
+    }
 
-  @Test
-  void movingOntoAPickupGrantsAShotAndConsumesIt() throws InterruptedException {
-    GridBoard board = new GridBoard(BOARD, BOARD, 1);
-    Player player = movingPlayer(1);
+    @Test
+    void movingOntoAPickupGrantsAShotAndConsumesIt() throws InterruptedException {
+        GridBoard board = new GridBoard(BOARD, BOARD, 1);
+        Player player = movingPlayer(1);
 
-    assertTrue(board.getNodeFromGrid(PICKUP_X, PICKUP_Y).isHasPickup(), "pickup should start present");
+        assertTrue(board.getNodeFromGrid(PICKUP_X, PICKUP_Y).isHasPickup(), "pickup should start present");
 
-    JavaFxToolkit.runOnFxThread(() -> board.movePlayer(player));
+        JavaFxToolkit.runOnFxThread(() -> board.movePlayer(player));
 
-    assertEquals(2, player.getNumberOfShots(), "ammo should increase by one");
-    assertFalse(board.getNodeFromGrid(PICKUP_X, PICKUP_Y).isHasPickup(), "pickup should be consumed");
-    assertEquals(PICKUP_X, player.getGridPositionX());
-    assertEquals(PICKUP_Y, player.getGridPositionY());
-    assertSame(player, board.getNodeFromGrid(PICKUP_X, PICKUP_Y).getPlayerInSpace());
-  }
+        assertEquals(2, player.getNumberOfShots(), "ammo should increase by one");
+        assertFalse(board.getNodeFromGrid(PICKUP_X, PICKUP_Y).isHasPickup(), "pickup should be consumed");
+        assertEquals(PICKUP_X, player.getGridPositionX());
+        assertEquals(PICKUP_Y, player.getGridPositionY());
+        assertSame(player, board.getNodeFromGrid(PICKUP_X, PICKUP_Y).getPlayerInSpace());
+    }
 
-  @Test
-  void aFullPlayerWalksOverThePickupWithoutConsumingIt() throws InterruptedException {
-    GridBoard board = new GridBoard(BOARD, BOARD, 1);
-    Player player = movingPlayer(3); // already at the cap
+    @Test
+    void aFullPlayerWalksOverThePickupWithoutConsumingIt() throws InterruptedException {
+        GridBoard board = new GridBoard(BOARD, BOARD, 1);
+        Player player = movingPlayer(3); // already at the cap
 
-    JavaFxToolkit.runOnFxThread(() -> board.movePlayer(player));
+        JavaFxToolkit.runOnFxThread(() -> board.movePlayer(player));
 
-    assertEquals(3, player.getNumberOfShots(), "ammo stays at the cap");
-    assertTrue(board.getNodeFromGrid(PICKUP_X, PICKUP_Y).isHasPickup(), "pickup remains for later");
-    assertEquals(PICKUP_X, player.getGridPositionX());
-  }
+        assertEquals(3, player.getNumberOfShots(), "ammo stays at the cap");
+        assertTrue(board.getNodeFromGrid(PICKUP_X, PICKUP_Y).isHasPickup(), "pickup remains for later");
+        assertEquals(PICKUP_X, player.getGridPositionX());
+    }
 
-  @Test
-  void movingOntoAPlainTileLeavesAmmoUnchanged() throws InterruptedException {
-    GridBoard board = new GridBoard(BOARD, BOARD, 1);
-    Player player = new Player(1, 1, 1, 2, Directions.EAST, null); // (1,2) -> (2,2), both plain spaces
-    player.setTargetMove(new Move(2, 2));
+    @Test
+    void movingOntoAPlainTileLeavesAmmoUnchanged() throws InterruptedException {
+        GridBoard board = new GridBoard(BOARD, BOARD, 1);
+        Player player = new Player(1, 1, 1, 2, Directions.EAST, null); // (1,2) -> (2,2), both plain spaces
+        player.setTargetMove(new Move(2, 2));
 
-    JavaFxToolkit.runOnFxThread(() -> board.movePlayer(player));
+        JavaFxToolkit.runOnFxThread(() -> board.movePlayer(player));
 
-    assertEquals(1, player.getNumberOfShots());
-    assertEquals(2, player.getGridPositionX());
-    assertEquals(2, player.getGridPositionY());
-  }
+        assertEquals(1, player.getNumberOfShots());
+        assertEquals(2, player.getGridPositionX());
+        assertEquals(2, player.getGridPositionY());
+    }
 }

--- a/src/test/java/ca/ciccc/silverBullet/logic/GameLogicTest.java
+++ b/src/test/java/ca/ciccc/silverBullet/logic/GameLogicTest.java
@@ -18,139 +18,139 @@ import org.junit.jupiter.api.Test;
  */
 class GameLogicTest {
 
-  private static TilePredicate passable(String... rows) {
-    return (x, y) -> rows[y].charAt(x) != '#';
-  }
+    private static TilePredicate passable(String... rows) {
+        return (x, y) -> rows[y].charAt(x) != '#';
+    }
 
-  private static TilePredicate occupied(String... rows) {
-    return (x, y) -> rows[y].charAt(x) == 'X';
-  }
+    private static TilePredicate occupied(String... rows) {
+        return (x, y) -> rows[y].charAt(x) == 'X';
+    }
 
-  private static int maxX(String... rows) {
-    return rows[0].length() - 1;
-  }
+    private static int maxX(String... rows) {
+        return rows[0].length() - 1;
+    }
 
-  private static int maxY(String... rows) {
-    return rows.length - 1;
-  }
+    private static int maxY(String... rows) {
+        return rows.length - 1;
+    }
 
-  // ---- moveDestination -----------------------------------------------------
+    // ---- moveDestination -----------------------------------------------------
 
-  @Test
-  void movesOntoAdjacentEmptyTileInEachDirection() {
-    String[] board = {
-        "...",
-        "...",
-        "..."
-    };
-    // From the centre (1,1), one step each way.
-    assertArrayEquals(new int[] {1, 0},
-        GameLogic.moveDestination(1, 1, Directions.NORTH, maxX(board), maxY(board), passable(board), occupied(board)));
-    assertArrayEquals(new int[] {1, 2},
-        GameLogic.moveDestination(1, 1, Directions.SOUTH, maxX(board), maxY(board), passable(board), occupied(board)));
-    assertArrayEquals(new int[] {2, 1},
-        GameLogic.moveDestination(1, 1, Directions.EAST, maxX(board), maxY(board), passable(board), occupied(board)));
-    assertArrayEquals(new int[] {0, 1},
-        GameLogic.moveDestination(1, 1, Directions.WEST, maxX(board), maxY(board), passable(board), occupied(board)));
-  }
+    @Test
+    void movesOntoAdjacentEmptyTileInEachDirection() {
+        String[] board = {"...", "...", "..."};
+        // From the centre (1,1), one step each way.
+        assertArrayEquals(
+                new int[] {1, 0},
+                GameLogic.moveDestination(
+                        1, 1, Directions.NORTH, maxX(board), maxY(board), passable(board), occupied(board)));
+        assertArrayEquals(
+                new int[] {1, 2},
+                GameLogic.moveDestination(
+                        1, 1, Directions.SOUTH, maxX(board), maxY(board), passable(board), occupied(board)));
+        assertArrayEquals(
+                new int[] {2, 1},
+                GameLogic.moveDestination(
+                        1, 1, Directions.EAST, maxX(board), maxY(board), passable(board), occupied(board)));
+        assertArrayEquals(
+                new int[] {0, 1},
+                GameLogic.moveDestination(
+                        1, 1, Directions.WEST, maxX(board), maxY(board), passable(board), occupied(board)));
+    }
 
-  @Test
-  void refusesToMoveOffTheTopEdge() {
-    String[] board = {"...", "...", "..."};
-    assertNull(GameLogic.moveDestination(1, 0, Directions.NORTH, maxX(board), maxY(board), passable(board), occupied(board)));
-  }
+    @Test
+    void refusesToMoveOffTheTopEdge() {
+        String[] board = {"...", "...", "..."};
+        assertNull(GameLogic.moveDestination(
+                1, 0, Directions.NORTH, maxX(board), maxY(board), passable(board), occupied(board)));
+    }
 
-  @Test
-  void refusesToMoveOffTheBottomEdge() {
-    String[] board = {"...", "...", "..."};
-    assertNull(GameLogic.moveDestination(1, 2, Directions.SOUTH, maxX(board), maxY(board), passable(board), occupied(board)));
-  }
+    @Test
+    void refusesToMoveOffTheBottomEdge() {
+        String[] board = {"...", "...", "..."};
+        assertNull(GameLogic.moveDestination(
+                1, 2, Directions.SOUTH, maxX(board), maxY(board), passable(board), occupied(board)));
+    }
 
-  @Test
-  void refusesToMoveOffTheLeftAndRightEdges() {
-    String[] board = {"...", "...", "..."};
-    assertNull(GameLogic.moveDestination(0, 1, Directions.WEST, maxX(board), maxY(board), passable(board), occupied(board)));
-    assertNull(GameLogic.moveDestination(2, 1, Directions.EAST, maxX(board), maxY(board), passable(board), occupied(board)));
-  }
+    @Test
+    void refusesToMoveOffTheLeftAndRightEdges() {
+        String[] board = {"...", "...", "..."};
+        assertNull(GameLogic.moveDestination(
+                0, 1, Directions.WEST, maxX(board), maxY(board), passable(board), occupied(board)));
+        assertNull(GameLogic.moveDestination(
+                2, 1, Directions.EAST, maxX(board), maxY(board), passable(board), occupied(board)));
+    }
 
-  @Test
-  void refusesToMoveIntoAnImpassableTile() {
-    String[] board = {
-        ".#.",
-        "...",
-        "..."
-    };
-    // Facing NORTH from (1,1) into the wall at (1,0).
-    assertNull(GameLogic.moveDestination(1, 1, Directions.NORTH, maxX(board), maxY(board), passable(board), occupied(board)));
-  }
+    @Test
+    void refusesToMoveIntoAnImpassableTile() {
+        String[] board = {".#.", "...", "..."};
+        // Facing NORTH from (1,1) into the wall at (1,0).
+        assertNull(GameLogic.moveDestination(
+                1, 1, Directions.NORTH, maxX(board), maxY(board), passable(board), occupied(board)));
+    }
 
-  @Test
-  void refusesToMoveIntoATileHeldByAnotherPlayer() {
-    String[] board = {
-        "...",
-        ".X.",
-        "..."
-    };
-    // Facing EAST from (0,1) into the occupied tile at (1,1).
-    assertNull(GameLogic.moveDestination(0, 1, Directions.EAST, maxX(board), maxY(board), passable(board), occupied(board)));
-  }
+    @Test
+    void refusesToMoveIntoATileHeldByAnotherPlayer() {
+        String[] board = {"...", ".X.", "..."};
+        // Facing EAST from (0,1) into the occupied tile at (1,1).
+        assertNull(GameLogic.moveDestination(
+                0, 1, Directions.EAST, maxX(board), maxY(board), passable(board), occupied(board)));
+    }
 
-  // ---- shotEndpoint --------------------------------------------------------
+    // ---- shotEndpoint --------------------------------------------------------
 
-  @Test
-  void shotTravelsToTheFarEdgeAcrossOpenGround() {
-    String[] board = {"....."};
-    // Shooter at (0,0) facing EAST on an open 5-wide row stops on the last tile.
-    assertArrayEquals(new int[] {4, 0},
-        GameLogic.shotEndpoint(0, 0, Directions.EAST, maxX(board), maxY(board), passable(board)));
-  }
+    @Test
+    void shotTravelsToTheFarEdgeAcrossOpenGround() {
+        String[] board = {"....."};
+        // Shooter at (0,0) facing EAST on an open 5-wide row stops on the last tile.
+        assertArrayEquals(
+                new int[] {4, 0},
+                GameLogic.shotEndpoint(0, 0, Directions.EAST, maxX(board), maxY(board), passable(board)));
+    }
 
-  @Test
-  void shotStopsOnTheLastPassableTileBeforeAWall() {
-    String[] board = {".#..."};
-    // Wall sits at (1,0); the bullet from (0,0) EAST cannot even reach it, so
-    // the adjacent-wall case applies below. Shoot from beyond instead:
-    String[] board2 = {"...#."};
-    // Shooter at (0,0) EAST: passes (1,0),(2,0), wall at (3,0) -> stops at (2,0).
-    assertArrayEquals(new int[] {2, 0},
-        GameLogic.shotEndpoint(0, 0, Directions.EAST, maxX(board2), maxY(board2), passable(board2)));
-    // Sanity: with the wall adjacent the shot goes nowhere.
-    assertNull(GameLogic.shotEndpoint(0, 0, Directions.EAST, maxX(board), maxY(board), passable(board)));
-  }
+    @Test
+    void shotStopsOnTheLastPassableTileBeforeAWall() {
+        String[] board = {".#..."};
+        // Wall sits at (1,0); the bullet from (0,0) EAST cannot even reach it, so
+        // the adjacent-wall case applies below. Shoot from beyond instead:
+        String[] board2 = {"...#."};
+        // Shooter at (0,0) EAST: passes (1,0),(2,0), wall at (3,0) -> stops at (2,0).
+        assertArrayEquals(
+                new int[] {2, 0},
+                GameLogic.shotEndpoint(0, 0, Directions.EAST, maxX(board2), maxY(board2), passable(board2)));
+        // Sanity: with the wall adjacent the shot goes nowhere.
+        assertNull(GameLogic.shotEndpoint(0, 0, Directions.EAST, maxX(board), maxY(board), passable(board)));
+    }
 
-  @Test
-  void shotReturnsNullWhenTheNextTileIsImpassable() {
-    String[] board = {"##"};
-    assertNull(GameLogic.shotEndpoint(0, 0, Directions.EAST, maxX(board), maxY(board), passable(board)));
-  }
+    @Test
+    void shotReturnsNullWhenTheNextTileIsImpassable() {
+        String[] board = {"##"};
+        assertNull(GameLogic.shotEndpoint(0, 0, Directions.EAST, maxX(board), maxY(board), passable(board)));
+    }
 
-  @Test
-  void shotReturnsNullWhenFiredStraightOffTheEdge() {
-    String[] board = {"...."};
-    // Shooter already on the right edge facing further EAST.
-    assertNull(GameLogic.shotEndpoint(3, 0, Directions.EAST, maxX(board), maxY(board), passable(board)));
-  }
+    @Test
+    void shotReturnsNullWhenFiredStraightOffTheEdge() {
+        String[] board = {"...."};
+        // Shooter already on the right edge facing further EAST.
+        assertNull(GameLogic.shotEndpoint(3, 0, Directions.EAST, maxX(board), maxY(board), passable(board)));
+    }
 
-  @Test
-  void shotTravelsUpwardStoppingBelowAWall() {
-    // Column of 5 rows; wall at (0,1). Shooter at (0,4) facing NORTH.
-    String[] board = {
-        ".",
-        "#",
-        ".",
-        ".",
-        "."
-    };
-    // Passes (0,3),(0,2), wall at (0,1) -> stops at (0,2).
-    assertArrayEquals(new int[] {0, 2},
-        GameLogic.shotEndpoint(0, 4, Directions.NORTH, maxX(board), maxY(board), passable(board)));
-  }
+    @Test
+    void shotTravelsUpwardStoppingBelowAWall() {
+        // Column of 5 rows; wall at (0,1). Shooter at (0,4) facing NORTH.
+        String[] board = {".", "#", ".", ".", "."};
+        // Passes (0,3),(0,2), wall at (0,1) -> stops at (0,2).
+        assertArrayEquals(
+                new int[] {0, 2},
+                GameLogic.shotEndpoint(0, 4, Directions.NORTH, maxX(board), maxY(board), passable(board)));
+    }
 
-  @Test
-  void shotTravelsWestToTheLeftEdge() {
-    String[] board = {"....."};
-    // Shooter at (4,0) facing WEST across open ground stops at the left edge.
-    assertArrayEquals(new int[] {0, 0},
-        GameLogic.shotEndpoint(4, 0, Directions.WEST, maxX(board), maxY(board), passable(board)));
-  }
+    @Test
+    void shotTravelsWestToTheLeftEdge() {
+        String[] board = {"....."};
+        // Shooter at (4,0) facing WEST across open ground stops at the left edge.
+        assertArrayEquals(
+                new int[] {0, 0},
+                GameLogic.shotEndpoint(4, 0, Directions.WEST, maxX(board), maxY(board), passable(board)));
+    }
 }

--- a/src/test/java/ca/ciccc/silverBullet/logic/SimultaneousMovesTest.java
+++ b/src/test/java/ca/ciccc/silverBullet/logic/SimultaneousMovesTest.java
@@ -7,39 +7,34 @@ import org.junit.jupiter.api.Test;
 /** Tests for {@link GameLogic#resolveSimultaneousMoves(int[][])}. */
 class SimultaneousMovesTest {
 
-  @Test
-  void distinctTargetsAllMove() {
-    int[][] targets = {{1, 1}, {2, 2}, {3, 3}};
-    assertArrayEquals(new boolean[] {true, true, true},
-        GameLogic.resolveSimultaneousMoves(targets));
-  }
+    @Test
+    void distinctTargetsAllMove() {
+        int[][] targets = {{1, 1}, {2, 2}, {3, 3}};
+        assertArrayEquals(new boolean[] {true, true, true}, GameLogic.resolveSimultaneousMoves(targets));
+    }
 
-  @Test
-  void twoPlayersContestingATileBothStayPut() {
-    int[][] targets = {{4, 4}, {4, 4}};
-    assertArrayEquals(new boolean[] {false, false},
-        GameLogic.resolveSimultaneousMoves(targets));
-  }
+    @Test
+    void twoPlayersContestingATileBothStayPut() {
+        int[][] targets = {{4, 4}, {4, 4}};
+        assertArrayEquals(new boolean[] {false, false}, GameLogic.resolveSimultaneousMoves(targets));
+    }
 
-  @Test
-  void aThirdPlayerElsewhereDoesNotUnblockTheCollidingPair() {
-    // The bug: a third mover used to let the contending pair both move.
-    int[][] targets = {{4, 4}, {4, 4}, {3, 7}};
-    assertArrayEquals(new boolean[] {false, false, true},
-        GameLogic.resolveSimultaneousMoves(targets));
-  }
+    @Test
+    void aThirdPlayerElsewhereDoesNotUnblockTheCollidingPair() {
+        // The bug: a third mover used to let the contending pair both move.
+        int[][] targets = {{4, 4}, {4, 4}, {3, 7}};
+        assertArrayEquals(new boolean[] {false, false, true}, GameLogic.resolveSimultaneousMoves(targets));
+    }
 
-  @Test
-  void nonMoversAreNeverMoved() {
-    int[][] targets = {null, {2, 2}, null};
-    assertArrayEquals(new boolean[] {false, true, false},
-        GameLogic.resolveSimultaneousMoves(targets));
-  }
+    @Test
+    void nonMoversAreNeverMoved() {
+        int[][] targets = {null, {2, 2}, null};
+        assertArrayEquals(new boolean[] {false, true, false}, GameLogic.resolveSimultaneousMoves(targets));
+    }
 
-  @Test
-  void aSharedTargetBlocksAllContendersEvenThree() {
-    int[][] targets = {{5, 5}, {5, 5}, {5, 5}};
-    assertArrayEquals(new boolean[] {false, false, false},
-        GameLogic.resolveSimultaneousMoves(targets));
-  }
+    @Test
+    void aSharedTargetBlocksAllContendersEvenThree() {
+        int[][] targets = {{5, 5}, {5, 5}, {5, 5}};
+        assertArrayEquals(new boolean[] {false, false, false}, GameLogic.resolveSimultaneousMoves(targets));
+    }
 }

--- a/src/test/java/ca/ciccc/silverBullet/playerElements/PlayerActionQueueTest.java
+++ b/src/test/java/ca/ciccc/silverBullet/playerElements/PlayerActionQueueTest.java
@@ -17,123 +17,123 @@ import org.junit.jupiter.api.Test;
  */
 class PlayerActionQueueTest {
 
-  private static final int SLOTS = 5;
+    private static final int SLOTS = 5;
 
-  @BeforeAll
-  static void startJavaFx() throws InterruptedException {
-    JavaFxToolkit.init();
-  }
-
-  private static Player newPlayer() {
-    return new Player(3, 1, 0, 0, Directions.NORTH, null);
-  }
-
-  private static PlayerAction[] filled(PlayerAction... actions) {
-    PlayerAction[] expected = new PlayerAction[SLOTS];
-    for (int i = 0; i < SLOTS; i++) {
-      expected[i] = i < actions.length ? actions[i] : PlayerAction.NONE;
-    }
-    return expected;
-  }
-
-  @Test
-  void aFreshPlayerHasAnEmptyQueue() {
-    Player player = newPlayer();
-    assertArrayEquals(filled(), player.getPlayerActions());
-    assertEquals(0, player.getCurrentAction());
-    assertFalse(player.isActionsFull());
-  }
-
-  @Test
-  void addActionFillsSlotsInOrder() {
-    Player player = newPlayer();
-    player.addAction(PlayerAction.MOVE);
-    player.addAction(PlayerAction.TURN_LEFT);
-
-    assertArrayEquals(filled(PlayerAction.MOVE, PlayerAction.TURN_LEFT), player.getPlayerActions());
-    assertEquals(2, player.getCurrentAction());
-    assertFalse(player.isActionsFull());
-  }
-
-  @Test
-  void queueBecomesFullAndCurrentActionResetsAfterFiveActions() {
-    Player player = newPlayer();
-    for (int i = 0; i < SLOTS; i++) {
-      player.addAction(PlayerAction.MOVE);
+    @BeforeAll
+    static void startJavaFx() throws InterruptedException {
+        JavaFxToolkit.init();
     }
 
-    assertTrue(player.isActionsFull());
-    assertEquals(0, player.getCurrentAction(), "currentAction wraps back to 0 once full");
-    assertArrayEquals(
-        filled(PlayerAction.MOVE, PlayerAction.MOVE, PlayerAction.MOVE, PlayerAction.MOVE, PlayerAction.MOVE),
-        player.getPlayerActions());
-  }
-
-  @Test
-  void addActionIsIgnoredOnceTheQueueIsFull() {
-    Player player = newPlayer();
-    for (int i = 0; i < SLOTS; i++) {
-      player.addAction(PlayerAction.MOVE);
+    private static Player newPlayer() {
+        return new Player(3, 1, 0, 0, Directions.NORTH, null);
     }
 
-    player.addAction(PlayerAction.SHOOT); // should be dropped
-
-    assertTrue(player.isActionsFull());
-    assertArrayEquals(
-        filled(PlayerAction.MOVE, PlayerAction.MOVE, PlayerAction.MOVE, PlayerAction.MOVE, PlayerAction.MOVE),
-        player.getPlayerActions());
-  }
-
-  @Test
-  void passTurnPadsRemainingSlotsWithWait() {
-    Player player = newPlayer();
-    player.addAction(PlayerAction.MOVE);
-    player.addAction(PlayerAction.SHOOT);
-
-    player.passTurn();
-
-    assertArrayEquals(
-        filled(PlayerAction.MOVE, PlayerAction.SHOOT, PlayerAction.WAIT, PlayerAction.WAIT, PlayerAction.WAIT),
-        player.getPlayerActions());
-    assertTrue(player.isActionsFull());
-  }
-
-  @Test
-  void passTurnOnAnEmptyQueueFillsItEntirelyWithWait() {
-    Player player = newPlayer();
-
-    player.passTurn();
-
-    assertArrayEquals(
-        filled(PlayerAction.WAIT, PlayerAction.WAIT, PlayerAction.WAIT, PlayerAction.WAIT, PlayerAction.WAIT),
-        player.getPlayerActions());
-    assertTrue(player.isActionsFull());
-  }
-
-  @Test
-  void passTurnLeavesAnAlreadyFullQueueUnchanged() {
-    Player player = newPlayer();
-    for (int i = 0; i < SLOTS; i++) {
-      player.addAction(PlayerAction.MOVE);
+    private static PlayerAction[] filled(PlayerAction... actions) {
+        PlayerAction[] expected = new PlayerAction[SLOTS];
+        for (int i = 0; i < SLOTS; i++) {
+            expected[i] = i < actions.length ? actions[i] : PlayerAction.NONE;
+        }
+        return expected;
     }
 
-    player.passTurn();
-
-    assertArrayEquals(
-        filled(PlayerAction.MOVE, PlayerAction.MOVE, PlayerAction.MOVE, PlayerAction.MOVE, PlayerAction.MOVE),
-        player.getPlayerActions());
-  }
-
-  @Test
-  void resetActionsClearsTheQueueAndTheFullFlag() {
-    Player player = newPlayer();
-    for (int i = 0; i < SLOTS; i++) {
-      player.addAction(PlayerAction.MOVE);
+    @Test
+    void aFreshPlayerHasAnEmptyQueue() {
+        Player player = newPlayer();
+        assertArrayEquals(filled(), player.getPlayerActions());
+        assertEquals(0, player.getCurrentAction());
+        assertFalse(player.isActionsFull());
     }
 
-    player.resetActions();
+    @Test
+    void addActionFillsSlotsInOrder() {
+        Player player = newPlayer();
+        player.addAction(PlayerAction.MOVE);
+        player.addAction(PlayerAction.TURN_LEFT);
 
-    assertArrayEquals(filled(), player.getPlayerActions());
-    assertFalse(player.isActionsFull());
-  }
+        assertArrayEquals(filled(PlayerAction.MOVE, PlayerAction.TURN_LEFT), player.getPlayerActions());
+        assertEquals(2, player.getCurrentAction());
+        assertFalse(player.isActionsFull());
+    }
+
+    @Test
+    void queueBecomesFullAndCurrentActionResetsAfterFiveActions() {
+        Player player = newPlayer();
+        for (int i = 0; i < SLOTS; i++) {
+            player.addAction(PlayerAction.MOVE);
+        }
+
+        assertTrue(player.isActionsFull());
+        assertEquals(0, player.getCurrentAction(), "currentAction wraps back to 0 once full");
+        assertArrayEquals(
+                filled(PlayerAction.MOVE, PlayerAction.MOVE, PlayerAction.MOVE, PlayerAction.MOVE, PlayerAction.MOVE),
+                player.getPlayerActions());
+    }
+
+    @Test
+    void addActionIsIgnoredOnceTheQueueIsFull() {
+        Player player = newPlayer();
+        for (int i = 0; i < SLOTS; i++) {
+            player.addAction(PlayerAction.MOVE);
+        }
+
+        player.addAction(PlayerAction.SHOOT); // should be dropped
+
+        assertTrue(player.isActionsFull());
+        assertArrayEquals(
+                filled(PlayerAction.MOVE, PlayerAction.MOVE, PlayerAction.MOVE, PlayerAction.MOVE, PlayerAction.MOVE),
+                player.getPlayerActions());
+    }
+
+    @Test
+    void passTurnPadsRemainingSlotsWithWait() {
+        Player player = newPlayer();
+        player.addAction(PlayerAction.MOVE);
+        player.addAction(PlayerAction.SHOOT);
+
+        player.passTurn();
+
+        assertArrayEquals(
+                filled(PlayerAction.MOVE, PlayerAction.SHOOT, PlayerAction.WAIT, PlayerAction.WAIT, PlayerAction.WAIT),
+                player.getPlayerActions());
+        assertTrue(player.isActionsFull());
+    }
+
+    @Test
+    void passTurnOnAnEmptyQueueFillsItEntirelyWithWait() {
+        Player player = newPlayer();
+
+        player.passTurn();
+
+        assertArrayEquals(
+                filled(PlayerAction.WAIT, PlayerAction.WAIT, PlayerAction.WAIT, PlayerAction.WAIT, PlayerAction.WAIT),
+                player.getPlayerActions());
+        assertTrue(player.isActionsFull());
+    }
+
+    @Test
+    void passTurnLeavesAnAlreadyFullQueueUnchanged() {
+        Player player = newPlayer();
+        for (int i = 0; i < SLOTS; i++) {
+            player.addAction(PlayerAction.MOVE);
+        }
+
+        player.passTurn();
+
+        assertArrayEquals(
+                filled(PlayerAction.MOVE, PlayerAction.MOVE, PlayerAction.MOVE, PlayerAction.MOVE, PlayerAction.MOVE),
+                player.getPlayerActions());
+    }
+
+    @Test
+    void resetActionsClearsTheQueueAndTheFullFlag() {
+        Player player = newPlayer();
+        for (int i = 0; i < SLOTS; i++) {
+            player.addAction(PlayerAction.MOVE);
+        }
+
+        player.resetActions();
+
+        assertArrayEquals(filled(), player.getPlayerActions());
+        assertFalse(player.isActionsFull());
+    }
 }

--- a/src/test/java/ca/ciccc/silverBullet/playerElements/PlayerAmmoTest.java
+++ b/src/test/java/ca/ciccc/silverBullet/playerElements/PlayerAmmoTest.java
@@ -12,47 +12,47 @@ import org.junit.jupiter.api.Test;
 /** Tests for a player's ammo counter ({@code addShot} / {@code isHasShot}). */
 class PlayerAmmoTest {
 
-  @BeforeAll
-  static void startJavaFx() throws InterruptedException {
-    JavaFxToolkit.init();
-  }
+    @BeforeAll
+    static void startJavaFx() throws InterruptedException {
+        JavaFxToolkit.init();
+    }
 
-  private static Player playerWithShots(int shots) {
-    return new Player(shots, 1, 0, 0, Directions.NORTH, null);
-  }
+    private static Player playerWithShots(int shots) {
+        return new Player(shots, 1, 0, 0, Directions.NORTH, null);
+    }
 
-  @Test
-  void aPlayerWithZeroShotsHasNoAmmo() {
-    Player player = playerWithShots(0);
-    assertEquals(0, player.getNumberOfShots());
-    assertFalse(player.isHasShot());
-  }
+    @Test
+    void aPlayerWithZeroShotsHasNoAmmo() {
+        Player player = playerWithShots(0);
+        assertEquals(0, player.getNumberOfShots());
+        assertFalse(player.isHasShot());
+    }
 
-  @Test
-  void aPlayerWithShotsHasAmmo() {
-    Player player = playerWithShots(2);
-    assertEquals(2, player.getNumberOfShots());
-    assertTrue(player.isHasShot());
-  }
+    @Test
+    void aPlayerWithShotsHasAmmo() {
+        Player player = playerWithShots(2);
+        assertEquals(2, player.getNumberOfShots());
+        assertTrue(player.isHasShot());
+    }
 
-  @Test
-  void addShotIncrementsAmmo() {
-    Player player = playerWithShots(0);
+    @Test
+    void addShotIncrementsAmmo() {
+        Player player = playerWithShots(0);
 
-    player.addShot();
+        player.addShot();
 
-    assertEquals(1, player.getNumberOfShots());
-    assertTrue(player.isHasShot());
-  }
+        assertEquals(1, player.getNumberOfShots());
+        assertTrue(player.isHasShot());
+    }
 
-  @Test
-  void addShotIsCappedAtThree() {
-    Player player = playerWithShots(2);
+    @Test
+    void addShotIsCappedAtThree() {
+        Player player = playerWithShots(2);
 
-    player.addShot(); // 3
-    player.addShot(); // capped
-    player.addShot(); // capped
+        player.addShot(); // 3
+        player.addShot(); // capped
+        player.addShot(); // capped
 
-    assertEquals(3, player.getNumberOfShots());
-  }
+        assertEquals(3, player.getNumberOfShots());
+    }
 }

--- a/src/test/java/ca/ciccc/silverBullet/testsupport/JavaFxToolkit.java
+++ b/src/test/java/ca/ciccc/silverBullet/testsupport/JavaFxToolkit.java
@@ -13,42 +13,41 @@ import javafx.application.Platform;
  */
 public final class JavaFxToolkit {
 
-  private JavaFxToolkit() {
-  }
+    private JavaFxToolkit() {}
 
-  /** Idempotent: safe to call from every test class's {@code @BeforeAll}. */
-  public static void init() throws InterruptedException {
-    CountDownLatch ready = new CountDownLatch(1);
-    try {
-      Platform.startup(ready::countDown);
-    } catch (IllegalStateException alreadyStarted) {
-      // The toolkit is already up (another test started it); nothing to do.
-      ready.countDown();
+    /** Idempotent: safe to call from every test class's {@code @BeforeAll}. */
+    public static void init() throws InterruptedException {
+        CountDownLatch ready = new CountDownLatch(1);
+        try {
+            Platform.startup(ready::countDown);
+        } catch (IllegalStateException alreadyStarted) {
+            // The toolkit is already up (another test started it); nothing to do.
+            ready.countDown();
+        }
+        ready.await();
     }
-    ready.await();
-  }
 
-  /**
-   * Run {@code action} on the JavaFX Application Thread and block until it
-   * finishes. Needed for operations that start animations (e.g. player moves),
-   * which must be invoked on the FX thread. Any thrown exception is rethrown to
-   * the caller so the test fails.
-   */
-  public static void runOnFxThread(Runnable action) throws InterruptedException {
-    CountDownLatch done = new CountDownLatch(1);
-    AtomicReference<Throwable> error = new AtomicReference<>();
-    Platform.runLater(() -> {
-      try {
-        action.run();
-      } catch (Throwable t) {
-        error.set(t);
-      } finally {
-        done.countDown();
-      }
-    });
-    done.await();
-    if (error.get() != null) {
-      throw new RuntimeException(error.get());
+    /**
+     * Run {@code action} on the JavaFX Application Thread and block until it
+     * finishes. Needed for operations that start animations (e.g. player moves),
+     * which must be invoked on the FX thread. Any thrown exception is rethrown to
+     * the caller so the test fails.
+     */
+    public static void runOnFxThread(Runnable action) throws InterruptedException {
+        CountDownLatch done = new CountDownLatch(1);
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        Platform.runLater(() -> {
+            try {
+                action.run();
+            } catch (Throwable t) {
+                error.set(t);
+            } finally {
+                done.countDown();
+            }
+        });
+        done.await();
+        if (error.get() != null) {
+            throw new RuntimeException(error.get());
+        }
     }
-  }
 }

--- a/src/test/java/ca/ciccc/silverBullet/utils/LevelFileReadUtilTest.java
+++ b/src/test/java/ca/ciccc/silverBullet/utils/LevelFileReadUtilTest.java
@@ -7,40 +7,40 @@ import org.junit.jupiter.api.Test;
 
 class LevelFileReadUtilTest {
 
-  @Test
-  void everyBundledLevelLoadsAsANineByNineGrid() {
-    for (int level = 1; level <= 3; level++) {
-      char[][] map = LevelFileReadUtil.getLevelMapAry(level);
-      assertEquals(9, map.length, "level " + level + " should have 9 rows");
-      for (int row = 0; row < 9; row++) {
-        assertEquals(9, map[row].length, "level " + level + " row " + row + " should have 9 columns");
-      }
+    @Test
+    void everyBundledLevelLoadsAsANineByNineGrid() {
+        for (int level = 1; level <= 3; level++) {
+            char[][] map = LevelFileReadUtil.getLevelMapAry(level);
+            assertEquals(9, map.length, "level " + level + " should have 9 rows");
+            for (int row = 0; row < 9; row++) {
+                assertEquals(9, map[row].length, "level " + level + " row " + row + " should have 9 columns");
+            }
+        }
     }
-  }
 
-  @Test
-  void wrapsTheBoardInEdgeTiles() {
-    char[][] map = LevelFileReadUtil.getLevelMapAry(1);
-    for (int i = 0; i < 9; i++) {
-      assertEquals('E', map[0][i], "top row must be all edges");
-      assertEquals('E', map[8][i], "bottom row must be all edges");
-      assertEquals('E', map[i][0], "left column must be all edges");
-      assertEquals('E', map[i][8], "right column must be all edges");
+    @Test
+    void wrapsTheBoardInEdgeTiles() {
+        char[][] map = LevelFileReadUtil.getLevelMapAry(1);
+        for (int i = 0; i < 9; i++) {
+            assertEquals('E', map[0][i], "top row must be all edges");
+            assertEquals('E', map[8][i], "bottom row must be all edges");
+            assertEquals('E', map[i][0], "left column must be all edges");
+            assertEquals('E', map[i][8], "right column must be all edges");
+        }
     }
-  }
 
-  @Test
-  void parsesPlayerStartPositionsAtTheExpectedCoordinates() {
-    // level1.txt places the four start markers just inside the corners.
-    char[][] map = LevelFileReadUtil.getLevelMapAry(1);
-    assertEquals('1', map[1][2]);
-    assertEquals('4', map[1][6]);
-    assertEquals('3', map[7][2]);
-    assertEquals('2', map[7][6]);
-  }
+    @Test
+    void parsesPlayerStartPositionsAtTheExpectedCoordinates() {
+        // level1.txt places the four start markers just inside the corners.
+        char[][] map = LevelFileReadUtil.getLevelMapAry(1);
+        assertEquals('1', map[1][2]);
+        assertEquals('4', map[1][6]);
+        assertEquals('3', map[7][2]);
+        assertEquals('2', map[7][6]);
+    }
 
-  @Test
-  void throwsForANonExistentLevel() {
-    assertThrows(RuntimeException.class, () -> LevelFileReadUtil.getLevelMapAry(0));
-  }
+    @Test
+    void throwsForANonExistentLevel() {
+        assertThrows(RuntimeException.class, () -> LevelFileReadUtil.getLevelMapAry(0));
+    }
 }


### PR DESCRIPTION
Build modernization, split into reviewable commits. Each commit builds green (`mvn clean verify`).

## What changed
- **Java 12 → 21** (`4368a4a`): compiler + javafx-maven-plugin `release` bumped to match the installed JDK and JavaFX 21 runtime. Dropped unused `javafx-web` / `javafx-swing` deps.
- **JUnit engine made explicit** (`2f19e3f`): tests previously ran only because Surefire silently auto-provisioned `junit-jupiter-engine`. Now imports `junit-bom`, depends on the `junit-jupiter` aggregator, and pins Surefire 3.5.4.
- **Enforcer** (`39bda08`): requires Java 21+ / Maven 3.9+, `dependencyConvergence`, `banDuplicatePomDependencyVersions`.
- **Spotless** (`660a2ea` + reformat `763d7ff`): palantir-java-format enforced at `process-sources` (runs in CI's `mvn test`). Bulk reformat isolated in its own commit + `.git-blame-ignore-revs`.
- **CI comment fix** (`6452e3d`): stale `--release 12` note corrected.

## Verification
`mvn clean verify` locally: 4 enforcer rules pass, Spotless reports 55 files clean, **73 tests pass**, jlink image builds.

## Notes
- The `763d7ff` reformat is a 54-file diff — expected first-formatter churn, isolated so `git blame` can skip it.
- Dropped enforcer's `requirePluginVersions` rule; it flagged Maven's own default-lifecycle plugins for little benefit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)