### PR TITLE
fix: point .git-blame-ignore-revs at the squash-merge SHA

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -2,5 +2,6 @@
 # Enable locally with:
 #   git config blame.ignoreRevsFile .git-blame-ignore-revs
 
-# style: apply Palantir Java format across the codebase
-763d7ffac88fab99bdaf6e3a53fbe6a304ca9fc9
+# chore: modernize build (#51) — squash-merged; the bulk Palantir reformat
+# of all sources landed as part of this commit.
+44e8c66aea162161b1dd801aef390154712fff21


### PR DESCRIPTION
Follow-up to #51.

That PR was squash-merged, so the original isolated reformat commit (`763d7ff`) is not in `master`'s history. `.git-blame-ignore-revs` still referenced it, which would make `git blame --ignore-revs-file` fail on a fresh clone. This repoints the entry at the squash commit `44e8c66`, which carries the bulk Palantir reformat.

Verified: the SHA is in master history and `git blame --ignore-revs-file` accepts the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)